### PR TITLE
Adding support for GAUGE_CSHARP_PROJECT_CONFIG configuration

### DIFF
--- a/src/GaugeProjectBuilder.cs
+++ b/src/GaugeProjectBuilder.cs
@@ -30,7 +30,8 @@ namespace Gauge.Dotnet
         {
             var gaugeBinDir = Utils.GetGaugeBinDir();
             var csprojEnvVariable = Utils.TryReadEnvValue("GAUGE_CSHARP_PROJECT_FILE");
-            var commandArgs = $"publish --configuration=release --output=\"{gaugeBinDir}\"";
+            string configurationEnvVariable = ReadBuildConfiguration();
+            var commandArgs = $"publish --configuration={configurationEnvVariable} --output=\"{gaugeBinDir}\"";
             if (!string.IsNullOrEmpty(csprojEnvVariable)) commandArgs = $"{commandArgs} \"{csprojEnvVariable}\"";
             try
             {
@@ -59,6 +60,16 @@ namespace Gauge.Dotnet
             buildProcess.ErrorDataReceived += (sender, e) => { Logger.Error(e.Data); };
             buildProcess.Start();
             buildProcess.WaitForExit();
+        }
+
+        private static string ReadBuildConfiguration()
+        {
+            var configurationEnvVariable = Utils.TryReadEnvValue("GAUGE_CSHARP_PROJECT_CONFIG");
+            if (string.IsNullOrEmpty(configurationEnvVariable))
+            {
+                configurationEnvVariable = "release";
+            }
+            return configurationEnvVariable;
         }
     }
 }

--- a/src/SetupCommand.cs
+++ b/src/SetupCommand.cs
@@ -42,7 +42,7 @@ namespace Gauge.Dotnet
 
 </Project>
 ";
-            var properties = $"GAUGE_CSHARP_PROJECT_FILE={projName}.csproj";
+            string properties = GenerateDefaultProperties(projName);
 
             var implementation = $@"using System;
 using System.Collections.Generic;
@@ -106,6 +106,16 @@ namespace {projName}
 
             logger.Info($"create  {Path.Combine("env", "default", "dotnet.properties")}");
             File.WriteAllText(Path.Combine(envPath, "dotnet.properties"), properties);
+        }
+
+        private static string GenerateDefaultProperties(string projName)
+        {
+            var properties = new[]
+            {
+                $"GAUGE_CSHARP_PROJECT_FILE={projName}.csproj",
+                "GAUGE_CSHARP_PROJECT_CONFIG=release"
+            };
+            return string.Join(System.Environment.NewLine, properties);
         }
     }
 }


### PR DESCRIPTION
This PR resolves #11 by reading the **GAUGE_CSHARP_PROJECT_CONFIG** variable in the **GaugeProjectBuilder** class.