### PR TITLE
Upgrading to Gauge.CSharp.Lib 0.7.6

### DIFF
--- a/IntegrationTestSample/gauge_bin/IntegrationTestSample.deps.json
+++ b/IntegrationTestSample/gauge_bin/IntegrationTestSample.deps.json
@@ -8,17 +8,17 @@
     ".NETCoreApp,Version=v2.0": {
       "IntegrationTestSample/1.0.0": {
         "dependencies": {
-          "Gauge.CSharp.Lib": "0.7.5"
+          "Gauge.CSharp.Lib": "0.7.6"
         },
         "runtime": {
           "IntegrationTestSample.dll": {}
         }
       },
-      "Gauge.CSharp.Lib/0.7.5": {
+      "Gauge.CSharp.Lib/0.7.6": {
         "runtime": {
           "lib/netstandard2.0/Gauge.CSharp.Lib.dll": {
-            "assemblyVersion": "0.7.5.0",
-            "fileVersion": "0.7.5.0"
+            "assemblyVersion": "0.7.6.0",
+            "fileVersion": "0.7.6.0"
           }
         }
       }
@@ -30,12 +30,12 @@
       "serviceable": false,
       "sha512": ""
     },
-    "Gauge.CSharp.Lib/0.7.5": {
+    "Gauge.CSharp.Lib/0.7.6": {
       "type": "package",
       "serviceable": true,
       "sha512": "sha512-Kx+FpiDvNcDU5FyINf3WTMRftTp6nRtUBoVpDFPBhJXO3QIaeuEMjjUrPMzFpP4FX2XFE8/aeckPn1W4rBKq5w==",
-      "path": "gauge.csharp.lib/0.7.5",
-      "hashPath": "gauge.csharp.lib.0.7.5.nupkg.sha512"
+      "path": "gauge.csharp.lib/0.7.6",
+      "hashPath": "gauge.csharp.lib.0.7.6.nupkg.sha512"
     }
   }
 }

--- a/src/SetupCommand.cs
+++ b/src/SetupCommand.cs
@@ -37,7 +37,7 @@ namespace Gauge.Dotnet
 
   <ItemGroup>
     <PackageReference Include=""FluentAssertions"" Version=""5.1.0"" />
-    <PackageReference Include=""Gauge.CSharp.Lib"" Version=""0.7.5"" />
+    <PackageReference Include=""Gauge.CSharp.Lib"" Version=""0.7.6"" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Fixes a build failure for a package downgrade that I was getting when running `./run.cmd build` on Windows 10. I suspect that these errors are a a result of [73a36a5](https://github.com/getgauge/gauge-dotnet/commit/73a36a51ddf60157a70afe360a516d4ee5477d57).

```
PS C:\dev\OpenSource\gauge-dotnet> ./run.cmd build
Microsoft (R) Build Engine version 16.2.37902+b5aaefc9f for .NET Core
Copyright (C) Microsoft Corporation. All rights reserved.

C:\dev\OpenSource\gauge-dotnet\integration-test\Gauge.Dotnet.IntegrationTests.csproj : error NU1605: Detected package downgrade: Gauge.CSharp.Lib from 0.7.6 to 0.7.5. Reference the package directly from the project to select a different version.  [C:\dev\OpenSource\gauge-dotnet\Gauge.Dotnet.sln]
C:\dev\OpenSource\gauge-dotnet\integration-test\Gauge.Dotnet.IntegrationTests.csproj : error NU1605:  Gauge.Dotnet.IntegrationTests -> Runner.NetCore20 -> Gauge.CSharp.Lib (>= 0.7.6)  [C:\dev\OpenSource\gauge-dotnet\Gauge.Dotnet.sln]
C:\dev\OpenSource\gauge-dotnet\integration-test\Gauge.Dotnet.IntegrationTests.csproj : error NU1605:  Gauge.Dotnet.IntegrationTests -> Gauge.CSharp.Lib (>= 0.7.5) 
[C:\dev\OpenSource\gauge-dotnet\Gauge.Dotnet.sln]
C:\dev\OpenSource\gauge-dotnet\test\Gauge.Dotnet.UnitTests.csproj : error NU1605: Detected package downgrade: Gauge.CSharp.Lib from 0.7.6 to 0.7.5. Reference the package directly from the project to select a different version.  [C:\dev\OpenSource\gauge-dotnet\Gauge.Dotnet.sln]
C:\dev\OpenSource\gauge-dotnet\test\Gauge.Dotnet.UnitTests.csproj : error NU1605:  Gauge.Dotnet.UnitTests -> Runner.NetCore20 -> Gauge.CSharp.Lib (>= 0.7.6)  [C:\dev\OpenSource\gauge-dotnet\Gauge.Dotnet.sln]
C:\dev\OpenSource\gauge-dotnet\test\Gauge.Dotnet.UnitTests.csproj : error NU1605:  Gauge.Dotnet.UnitTests -> Gauge.CSharp.Lib (>= 0.7.5) [C:\dev\OpenSource\gauge-dotnet\Gauge.Dotnet.sln]
  Restore completed in 691.1 ms for C:\dev\OpenSource\gauge-dotnet\src\Gauge.Dotnet.csproj.
  Restore failed in 691.11 ms for C:\dev\OpenSource\gauge-dotnet\integration-test\Gauge.Dotnet.IntegrationTests.csproj.
  Restore failed in 691.11 ms for C:\dev\OpenSource\gauge-dotnet\test\Gauge.Dotnet.UnitTests.csproj.

Build FAILED.
```