### PR TITLE
Upgrading to .NET Core 2.1

### DIFF
--- a/IntegrationTestSample/IntegrationTestSample.csproj
+++ b/IntegrationTestSample/IntegrationTestSample.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/IntegrationTestSample/gauge_bin/IntegrationTestSample.deps.json
+++ b/IntegrationTestSample/gauge_bin/IntegrationTestSample.deps.json
@@ -1,11 +1,11 @@
 {
   "runtimeTarget": {
-    "name": ".NETCoreApp,Version=v2.0",
+    "name": ".NETCoreApp,Version=v2.1",
     "signature": ""
   },
   "compilationOptions": {},
   "targets": {
-    ".NETCoreApp,Version=v2.0": {
+    ".NETCoreApp,Version=v2.1": {
       "IntegrationTestSample/1.0.0": {
         "dependencies": {
           "Gauge.CSharp.Lib": "0.7.5"
@@ -16,7 +16,7 @@
       },
       "Gauge.CSharp.Lib/0.7.5": {
         "runtime": {
-          "lib/netstandard2.0/Gauge.CSharp.Lib.dll": {
+          "lib/netstandard2.1/Gauge.CSharp.Lib.dll": {
             "assemblyVersion": "0.7.5.0",
             "fileVersion": "0.7.5.0"
           }

--- a/integration-test/Gauge.Dotnet.IntegrationTests.csproj
+++ b/integration-test/Gauge.Dotnet.IntegrationTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Gauge.Dotnet.csproj
+++ b/src/Gauge.Dotnet.csproj
@@ -2,8 +2,8 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
-    <PackageId>Runner.NetCore20</PackageId>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <PackageId>Runner.NetCore21</PackageId>
     <Authors>The Gauge Team</Authors>
     <Version>0.1.3</Version>
     <Company>ThoughtWorks Inc.</Company>

--- a/src/SetupCommand.cs
+++ b/src/SetupCommand.cs
@@ -32,7 +32,7 @@ namespace Gauge.Dotnet
             var project = $@"<Project Sdk=""Microsoft.NET.Sdk"">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>netstandard2.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/dotnet.json
+++ b/src/dotnet.json
@@ -1,7 +1,7 @@
 {
   "id": "dotnet",
   "version": "0.1.3",
-  "description": "C# support for gauge + .NET Core 2.0",
+  "description": "C# support for gauge + .NET Core 2.1",
   "run": {
     "windows": [
       "launcher.cmd",

--- a/test/Gauge.Dotnet.UnitTests.csproj
+++ b/test/Gauge.Dotnet.UnitTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <RootNamespace>Gauge.Dotnet.UnitTests</RootNamespace>
   </PropertyGroup>
 


### PR DESCRIPTION
According to [the .NET Core website](https://dotnet.microsoft.com/download/dotnet-core), .NET Core 2.0 reached end of support on 2018-10-01. But .NET Core 2.1 is an LTS version that will reach end of support on 2021-08-21.

This project should be relying on the supported version of .NET Core 2.x to avoid bugs and security issues.