### PR TITLE
Unload context after scanning, fixes #114

### DIFF
--- a/src/GaugeListener.cs
+++ b/src/GaugeListener.cs
@@ -31,17 +31,10 @@ namespace Gauge.Dotnet
                 var reflectionWrapper = new ReflectionWrapper();
                 var activatorWrapper = new ActivatorWrapper();
                 Logger.Debug($"Loading assembly from : {assemblyPath}");
-                if (string.Compare(Environment.GetEnvironmentVariable("IS_DAEMON"), "true", true) == 0)
+                var isDaemon = string.Compare(Environment.GetEnvironmentVariable("IS_DAEMON"), "true", true) == 0;
+                using (var gaugeLoadContext = new GaugeLoadContext(assemblyPath, isDaemon))
                 {
-                    using (var gaugeLoadContext = new DisposableGaugeLoadContext(assemblyPath))
-                    {
-                        var assemblyLoader = new AssemblyLoader(assemblyPath, gaugeLoadContext, reflectionWrapper, activatorWrapper, _staticLoader.GetStepRegistry());
-                        var handler = new RunnerServiceHandler(activatorWrapper,reflectionWrapper, assemblyLoader, _staticLoader, server);
-                        server.Services.Add(Runner.BindService(handler));
-                    }
-                } else {
-                    var assemblyLoader = new AssemblyLoader(assemblyPath, new GaugeLoadContext(assemblyPath), reflectionWrapper,
-                        activatorWrapper, _staticLoader.GetStepRegistry());
+                    var assemblyLoader = new AssemblyLoader(assemblyPath, gaugeLoadContext, reflectionWrapper, activatorWrapper, _staticLoader.GetStepRegistry());
                     var handler = new RunnerServiceHandler(activatorWrapper,reflectionWrapper, assemblyLoader, _staticLoader, server);
                     server.Services.Add(Runner.BindService(handler));
                 }

--- a/src/GaugeListener.cs
+++ b/src/GaugeListener.cs
@@ -31,10 +31,11 @@ namespace Gauge.Dotnet
                 var reflectionWrapper = new ReflectionWrapper();
                 var activatorWrapper = new ActivatorWrapper();
                 Logger.Debug($"Loading assembly from : {assemblyPath}");
-                var gaugeLoadContext = new GaugeLoadContext(assemblyPath);
-                var assemblyLoader = new AssemblyLoader(assemblyPath, gaugeLoadContext, reflectionWrapper, activatorWrapper, _staticLoader.GetStepRegistry());
-                var handler = new RunnerServiceHandler(activatorWrapper,reflectionWrapper, assemblyLoader, _staticLoader, server);
-                server.Services.Add(Runner.BindService(handler));
+                using (var gaugeLoadContext = new GaugeLoadContext(assemblyPath)) {
+                    var assemblyLoader = new AssemblyLoader(assemblyPath, gaugeLoadContext, reflectionWrapper, activatorWrapper, _staticLoader.GetStepRegistry());
+                    var handler = new RunnerServiceHandler(activatorWrapper,reflectionWrapper, assemblyLoader, _staticLoader, server);
+                    server.Services.Add(Runner.BindService(handler));
+                }
             } else {
                 var handler = new RunnerServiceHandler(_staticLoader, server);
                 server.Services.Add(Runner.BindService(handler));

--- a/src/GaugeListener.cs
+++ b/src/GaugeListener.cs
@@ -31,8 +31,17 @@ namespace Gauge.Dotnet
                 var reflectionWrapper = new ReflectionWrapper();
                 var activatorWrapper = new ActivatorWrapper();
                 Logger.Debug($"Loading assembly from : {assemblyPath}");
-                using (var gaugeLoadContext = new GaugeLoadContext(assemblyPath)) {
-                    var assemblyLoader = new AssemblyLoader(assemblyPath, gaugeLoadContext, reflectionWrapper, activatorWrapper, _staticLoader.GetStepRegistry());
+                if (string.Compare(Environment.GetEnvironmentVariable("IS_DAEMON"), "true", true) == 0)
+                {
+                    using (var gaugeLoadContext = new DisposableGaugeLoadContext(assemblyPath))
+                    {
+                        var assemblyLoader = new AssemblyLoader(assemblyPath, gaugeLoadContext, reflectionWrapper, activatorWrapper, _staticLoader.GetStepRegistry());
+                        var handler = new RunnerServiceHandler(activatorWrapper,reflectionWrapper, assemblyLoader, _staticLoader, server);
+                        server.Services.Add(Runner.BindService(handler));
+                    }
+                } else {
+                    var assemblyLoader = new AssemblyLoader(assemblyPath, new GaugeLoadContext(assemblyPath), reflectionWrapper,
+                        activatorWrapper, _staticLoader.GetStepRegistry());
                     var handler = new RunnerServiceHandler(activatorWrapper,reflectionWrapper, assemblyLoader, _staticLoader, server);
                     server.Services.Add(Runner.BindService(handler));
                 }

--- a/src/GaugeLoadContext.cs
+++ b/src/GaugeLoadContext.cs
@@ -11,7 +11,7 @@ using System.Runtime.Loader;
 
 namespace Gauge.Dotnet
 {
-    public class GaugeLoadContext: AssemblyLoadContext, IGaugeLoadContext, System.IDisposable
+    public class GaugeLoadContext: AssemblyLoadContext, IGaugeLoadContext
     {
         private const string GaugeLibAssemblyName = "Gauge.CSharp.Lib";
         private AssemblyDependencyResolver _resolver;
@@ -21,10 +21,9 @@ namespace Gauge.Dotnet
             _resolver = new AssemblyDependencyResolver(pluginPath);
         }
 
-        public void Dispose()
+        protected GaugeLoadContext(string pluginPath, bool collectible) : base(collectible)
         {
-            Logger.Debug("Unloading GaugeLoadContext, assemblies should be freed up.");
-            base.Unload();
+            _resolver = new AssemblyDependencyResolver(pluginPath);
         }
 
         public IEnumerable<Assembly> GetAssembliesReferencingGaugeLib()
@@ -42,5 +41,19 @@ namespace Gauge.Dotnet
             }
             return null;
         }
+    }
+
+    public class DisposableGaugeLoadContext : GaugeLoadContext, System.IDisposable
+    {
+        public DisposableGaugeLoadContext(string pluginPath) : base(pluginPath, true)
+        {
+        }
+
+        public void Dispose()
+        {
+            Logger.Debug("Unloading GaugeLoadContext, assemblies should be freed up.");
+            base.Unload();
+        }
+
     }
 }

--- a/src/GaugeLoadContext.cs
+++ b/src/GaugeLoadContext.cs
@@ -11,13 +11,20 @@ using System.Runtime.Loader;
 
 namespace Gauge.Dotnet
 {
-    public class GaugeLoadContext: AssemblyLoadContext, IGaugeLoadContext {
+    public class GaugeLoadContext: AssemblyLoadContext, IGaugeLoadContext, System.IDisposable
+    {
         private const string GaugeLibAssemblyName = "Gauge.CSharp.Lib";
         private AssemblyDependencyResolver _resolver;
 
         public GaugeLoadContext(string pluginPath)
         {
             _resolver = new AssemblyDependencyResolver(pluginPath);
+        }
+
+        public void Dispose()
+        {
+            Logger.Debug("Unloading GaugeLoadContext, assemblies should be freed up.");
+            base.Unload();
         }
 
         public IEnumerable<Assembly> GetAssembliesReferencingGaugeLib()

--- a/src/GaugeLoadContext.cs
+++ b/src/GaugeLoadContext.cs
@@ -11,19 +11,23 @@ using System.Runtime.Loader;
 
 namespace Gauge.Dotnet
 {
-    public class GaugeLoadContext: AssemblyLoadContext, IGaugeLoadContext
+    public class GaugeLoadContext: AssemblyLoadContext, IGaugeLoadContext, System.IDisposable
     {
         private const string GaugeLibAssemblyName = "Gauge.CSharp.Lib";
         private AssemblyDependencyResolver _resolver;
 
-        public GaugeLoadContext(string pluginPath)
+        public GaugeLoadContext(string pluginPath, bool collectibe = false) : base(collectibe)
         {
             _resolver = new AssemblyDependencyResolver(pluginPath);
         }
 
-        protected GaugeLoadContext(string pluginPath, bool collectible) : base(collectible)
+        public void Dispose()
         {
-            _resolver = new AssemblyDependencyResolver(pluginPath);
+            if (IsCollectible)
+            {
+                Logger.Debug("Unloading GaugeLoadContext, assemblies should be freed up.");
+                base.Unload();
+            }
         }
 
         public IEnumerable<Assembly> GetAssembliesReferencingGaugeLib()
@@ -41,19 +45,5 @@ namespace Gauge.Dotnet
             }
             return null;
         }
-    }
-
-    public class DisposableGaugeLoadContext : GaugeLoadContext, System.IDisposable
-    {
-        public DisposableGaugeLoadContext(string pluginPath) : base(pluginPath, true)
-        {
-        }
-
-        public void Dispose()
-        {
-            Logger.Debug("Unloading GaugeLoadContext, assemblies should be freed up.");
-            base.Unload();
-        }
-
     }
 }

--- a/src/GaugeLoadContext.cs
+++ b/src/GaugeLoadContext.cs
@@ -16,7 +16,7 @@ namespace Gauge.Dotnet
         private const string GaugeLibAssemblyName = "Gauge.CSharp.Lib";
         private AssemblyDependencyResolver _resolver;
 
-        public GaugeLoadContext(string pluginPath, bool collectibe = false) : base(collectibe)
+        public GaugeLoadContext(string pluginPath, bool collectible = false) : base(collectible)
         {
             _resolver = new AssemblyDependencyResolver(pluginPath);
         }


### PR DESCRIPTION
Fix for #114

Since 0.1.7, gauge-dotnet loads target assemblies in a custom load context, and this causes the assemblies to be locked.

Maring the `GaugeLoadContext` as `collectible` and invoking `Unload` after scan releases the assemblies. However, this has an undesirable sideeffect when running specs. The reflected types and methods are not available at time of running.

This PR checks if gauge-dotnet is used to power LanguageServer and conditionally marks `GaugeLoadContext` as collectible, and invokes `Unload`.