### PR TITLE
use different LoadContext for authoring/execution

### DIFF
--- a/src/Gauge.Dotnet.csproj
+++ b/src/Gauge.Dotnet.csproj
@@ -5,7 +5,7 @@
     <TargetFramework>netcoreapp3.0</TargetFramework>
     <PackageId>Runner.NetCore30</PackageId>
     <Authors>The Gauge Team</Authors>
-    <Version>0.1.8</Version>
+    <Version>0.1.9</Version>
     <Company>ThoughtWorks Inc.</Company>
     <Product>Gauge</Product>
     <Description>C# runner for Gauge. https://gauge.org</Description>

--- a/src/GaugeListener.cs
+++ b/src/GaugeListener.cs
@@ -32,12 +32,10 @@ namespace Gauge.Dotnet
                 var activatorWrapper = new ActivatorWrapper();
                 Logger.Debug($"Loading assembly from : {assemblyPath}");
                 var isDaemon = string.Compare(Environment.GetEnvironmentVariable("IS_DAEMON"), "true", true) == 0;
-                using (var gaugeLoadContext = new GaugeLoadContext(assemblyPath, isDaemon))
-                {
-                    var assemblyLoader = new AssemblyLoader(assemblyPath, gaugeLoadContext, reflectionWrapper, activatorWrapper, _staticLoader.GetStepRegistry());
-                    var handler = new RunnerServiceHandler(activatorWrapper,reflectionWrapper, assemblyLoader, _staticLoader, server);
-                    server.Services.Add(Runner.BindService(handler));
-                }
+                var gaugeLoadContext = isDaemon ? new LockFreeGaugeLoadContext(assemblyPath) : new GaugeLoadContext(assemblyPath);
+                var assemblyLoader = new AssemblyLoader(assemblyPath, gaugeLoadContext, reflectionWrapper, activatorWrapper, _staticLoader.GetStepRegistry());
+                var handler = new RunnerServiceHandler(activatorWrapper,reflectionWrapper, assemblyLoader, _staticLoader, server);
+                server.Services.Add(Runner.BindService(handler));
             } else {
                 var handler = new RunnerServiceHandler(_staticLoader, server);
                 server.Services.Add(Runner.BindService(handler));

--- a/src/GaugeLoadContext.cs
+++ b/src/GaugeLoadContext.cs
@@ -11,23 +11,14 @@ using System.Runtime.Loader;
 
 namespace Gauge.Dotnet
 {
-    public class GaugeLoadContext: AssemblyLoadContext, IGaugeLoadContext, System.IDisposable
+    public class GaugeLoadContext: AssemblyLoadContext, IGaugeLoadContext
     {
         private const string GaugeLibAssemblyName = "Gauge.CSharp.Lib";
-        private AssemblyDependencyResolver _resolver;
+        protected AssemblyDependencyResolver _resolver;
 
-        public GaugeLoadContext(string pluginPath, bool collectible = false) : base(collectible)
+        public GaugeLoadContext(string pluginPath)
         {
             _resolver = new AssemblyDependencyResolver(pluginPath);
-        }
-
-        public void Dispose()
-        {
-            if (IsCollectible)
-            {
-                Logger.Debug("Unloading GaugeLoadContext, assemblies should be freed up.");
-                base.Unload();
-            }
         }
 
         public IEnumerable<Assembly> GetAssembliesReferencingGaugeLib()
@@ -38,7 +29,7 @@ namespace Gauge.Dotnet
         protected override Assembly Load(AssemblyName assemblyName)
         {
             var assemblyPath = _resolver.ResolveAssemblyToPath(assemblyName);
-            Logger.Debug($"Try load {assemblyName.Name}");
+            Logger.Debug($"Try load {assemblyName.Name} in GaugeLoadContext");
             if (assemblyPath != null)
             {
                 return LoadFromAssemblyPath(assemblyPath);

--- a/src/LockFreeGaugeLoadContext.cs
+++ b/src/LockFreeGaugeLoadContext.cs
@@ -1,0 +1,38 @@
+/*----------------------------------------------------------------
+ *  Copyright (c) ThoughtWorks, Inc.
+ *  Licensed under the Apache License, Version 2.0
+ *  See LICENSE.txt in the project root for license information.
+ *----------------------------------------------------------------*/
+
+using System.Reflection;
+
+namespace Gauge.Dotnet
+{
+    /* NOTE: LockFreeGaugeLoadContext is required because GaugeLoadContext uses 
+    // AssemblyLoadContext.LoadFromAssemblyPath which holds a filesystem lock 
+    // on the assembly file. This causes Run/Debug to fail because these
+    // actions run as separate process and cannot write to build output dir.
+    // GaugeLoadContext is also required because certain assemblies are shipped
+    // with runtime specific artifacts, and loading raw bytes is risky, can 
+    // cause BadImageFormatException at runtime. */
+    public class LockFreeGaugeLoadContext : GaugeLoadContext
+    {
+        public LockFreeGaugeLoadContext(string pluginPath) : base(pluginPath)
+        {
+        }
+
+        protected override Assembly Load(AssemblyName assemblyName)
+        {
+            var assemblyPath = _resolver.ResolveAssemblyToPath(assemblyName);
+            Logger.Debug($"Try load {assemblyName.Name} in LockFreeGaugeLoadContext");
+            if (assemblyPath != null)
+            {
+                using (var fileStream = System.IO.File.OpenRead(assemblyPath))
+                {
+                    return LoadFromStream(fileStream);
+                }
+            }
+            return null;
+        }
+    }
+}

--- a/src/dotnet.json
+++ b/src/dotnet.json
@@ -1,6 +1,6 @@
 {
   "id": "dotnet",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "description": "C# support for gauge + .NET Core 3.0",
   "run": {
     "windows": [


### PR DESCRIPTION
- introduce LockFreeGaugeLoadContext to prevent assembly locks, fixes #114
- bump version -> 0.1.9
