### PR TITLE
remove read of csproj/static loading when GAUGE_CUSTOM_BUILD_PATH is set

### DIFF
--- a/src/Gauge.Dotnet.csproj
+++ b/src/Gauge.Dotnet.csproj
@@ -5,7 +5,7 @@
     <TargetFramework>netcoreapp3.0</TargetFramework>
     <PackageId>Runner.NetCore30</PackageId>
     <Authors>The Gauge Team</Authors>
-    <Version>0.1.9</Version>
+    <Version>0.2.0</Version>
     <Company>ThoughtWorks Inc.</Company>
     <Product>Gauge</Product>
     <Description>C# runner for Gauge. https://gauge.org</Description>

--- a/src/GaugeCommandFactory.cs
+++ b/src/GaugeCommandFactory.cs
@@ -5,6 +5,8 @@
  *----------------------------------------------------------------*/
 
 
+using Gauge.Dotnet.Wrappers;
+
 namespace Gauge.Dotnet
 {
     public class GaugeCommandFactory
@@ -18,7 +20,7 @@ namespace Gauge.Dotnet
                 default:
                     return new StartCommand(() =>
                         {
-                            var loader = new StaticLoader(new System.Lazy<IAttributesLoader>(() => new AttributesLoader()));
+                            var loader = new StaticLoader(new AttributesLoader(), new DirectoryWrapper());
                             loader.LoadImplementations();
                             return new GaugeListener(loader);
                         },

--- a/src/RunnerServiceHandler.cs
+++ b/src/RunnerServiceHandler.cs
@@ -163,10 +163,11 @@ namespace Gauge.Dotnet
 
         public override Task<ImplementationFileListResponse> GetImplementationFiles(Empty request, ServerCallContext context)
         {
-            var response = new ImplementationFileListResponse();
-            response.ImplementationFilePaths.AddRange(FileHelper.GetImplementationFiles());
-            return _pool.Execute(DefaultExecutionStream, () => response);
-
+            return _pool.Execute(DefaultExecutionStream,() => {
+                var response = new ImplementationFileListResponse();
+                response.ImplementationFilePaths.AddRange(FileHelper.GetImplementationFiles());
+                return response;
+            });
         }
 
         public override Task<StepNameResponse> GetStepName(StepNameRequest request, ServerCallContext context)

--- a/test/Processors/CacheFileProcessorTests.cs
+++ b/test/Processors/CacheFileProcessorTests.cs
@@ -8,6 +8,7 @@ using System;
 using System.Collections.Generic;
 using System.Xml.Linq;
 using Gauge.Dotnet.Processors;
+using Gauge.Dotnet.Wrappers;
 using Gauge.Messages;
 using Moq;
 using NUnit.Framework;
@@ -22,7 +23,8 @@ namespace Gauge.Dotnet.UnitTests.Processors
         {
             var mockAttributesLoader = new Mock<IAttributesLoader>();
             mockAttributesLoader.Setup(x => x.GetRemovedAttributes()).Returns(new List<XAttribute>());
-            var loader = new StaticLoader(new Lazy<IAttributesLoader>(() => mockAttributesLoader.Object));
+            var mockDirectoryWrapper = new Mock<IDirectoryWrapper>();
+            var loader = new StaticLoader(mockAttributesLoader.Object, mockDirectoryWrapper.Object);
 
             var processor = new CacheFileProcessor(loader);
             var request = new CacheFileRequest
@@ -52,7 +54,8 @@ namespace Gauge.Dotnet.UnitTests.Processors
         {
             var mockAttributesLoader = new Mock<IAttributesLoader>();
             mockAttributesLoader.Setup(x => x.GetRemovedAttributes()).Returns(new List<XAttribute>());
-            var loader = new StaticLoader(new Lazy<IAttributesLoader>(() => mockAttributesLoader.Object));
+            var mockDirectoryWrapper = new Mock<IDirectoryWrapper>();
+            var loader = new StaticLoader(mockAttributesLoader.Object, mockDirectoryWrapper.Object);
             const string content = "using Gauge.CSharp.Lib.Attributes;\n" +
                                    "namespace foobar\n" +
                                    "{\n" +

--- a/test/Processors/StepPositionsProcessorTests.cs
+++ b/test/Processors/StepPositionsProcessorTests.cs
@@ -10,6 +10,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Xml.Linq;
 using Gauge.Dotnet.Processors;
+using Gauge.Dotnet.Wrappers;
 using Gauge.Messages;
 using Moq;
 using NUnit.Framework;
@@ -23,7 +24,8 @@ namespace Gauge.Dotnet.UnitTests.Processors
         {
             var mockAttributesLoader = new Mock<IAttributesLoader>();
             mockAttributesLoader.Setup(x => x.GetRemovedAttributes()).Returns(new List<XAttribute>());
-            var loader = new StaticLoader(new Lazy<IAttributesLoader>(() => mockAttributesLoader.Object));
+            var mockDirectoryWrapper = new Mock<IDirectoryWrapper>();
+            var loader = new StaticLoader(mockAttributesLoader.Object, mockDirectoryWrapper.Object);
             const string content = "using Gauge.CSharp.Lib.Attributes;\n" +
                                    "namespace foobar\n" +
                                    "{\n" +
@@ -54,7 +56,8 @@ namespace Gauge.Dotnet.UnitTests.Processors
         {
             var mockAttributesLoader = new Mock<IAttributesLoader>();
             mockAttributesLoader.Setup(x => x.GetRemovedAttributes()).Returns(new List<XAttribute>());
-            var loader = new StaticLoader(new Lazy<IAttributesLoader>(() => mockAttributesLoader.Object));
+            var mockDirectoryWrapper = new Mock<IDirectoryWrapper>();
+            var loader = new StaticLoader(mockAttributesLoader.Object, mockDirectoryWrapper.Object);
             const string content = "using Gauge.CSharp.Lib.Attributes;\n" +
                                    "namespace foobar\n" +
                                    "{\n" +


### PR DESCRIPTION
This PR sets gauge-dotnet to skip static loading when `GAUGE_CUSTOM_BUILD_PATH` is set. Fixes getgauge/gauge#1739