### PR TITLE
Fix version conflicts caused by PR#165

### DIFF
--- a/src/Gauge.Dotnet.csproj
+++ b/src/Gauge.Dotnet.csproj
@@ -26,8 +26,8 @@
     <PackageReference Include="Gauge.CSharp.Core" Version="0.6.0" />
     <PackageReference Include="Gauge.CSharp.Lib" Version="0.9.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.2"/>
-    <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="3.7.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="3.7.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="3.10.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="3.10.0" />
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.1.2-alpha" />
   </ItemGroup>


### PR DESCRIPTION
I encountered a similar dependency hell issue when bump Microsoft.CodeAnalysis.CSharp from 3.7.0 to 3.10.0. [(PR#165)](https://github.com/getgauge/gauge-dotnet/pull/165).
Hope this fix can help you.

Best regards,
sucrose