### PR TITLE
Resolve Error: Timed out connecting to dotnet

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -1,19 +1,18 @@
 # Gauge-dotnet
+
 [![tests](https://github.com/getgauge/gauge-dotnet/workflows/tests/badge.svg)](https://github.com/getgauge/gauge-dotnet/actions?query=workflow%3Atests)
 [![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-v1.4%20adopted-ff69b4.svg)](CODE_OF_CONDUCT.md)
 
+This project adds a .NET [language plugin](https://gauge.org/plugins/) for [Gauge](https://gauge.org).
 
-This project adds dotnet-core [language plugin](https://gauge.org/plugins/) for [gauge](https://gauge.org).
-
-The plugin is authored in [c#](https://en.wikipedia.org/wiki/C_Sharp_(programming_language)).
+The plugin is authored in [C#](https://en.wikipedia.org/wiki/C_Sharp_(programming_language)).
 
 ## Getting started
 
-### Pre-requisite
+### Pre-requisites
 
-- [Gauge](https://gauge.org)
-- [Dotnet Core](https://docs.microsoft.com/en-us/dotnet/core/index)
-
+- [Gauge](https://gauge.org/)
+- [.NET](https://learn.microsoft.com/en-us/dotnet/fundamentals/)
 
 ### Installation
 
@@ -21,7 +20,7 @@ The plugin is authored in [c#](https://en.wikipedia.org/wiki/C_Sharp_(programmin
 gauge install dotnet
 ```
 
-### Create a gauge-dotnet project
+### Create a Gauge .NET project
 
 ```
 gauge init dotnet
@@ -36,35 +35,36 @@ gauge run specs
 ### Alternate Installation options
 
 #### Install specific version
-* Installing specific version
+
 ```
-gauge install dotnet --version 0.5.0
+gauge install dotnet --version 0.5.2
 ```
 
 #### Offline installation
 
-* Download the plugin from [Releases](https://github.com/getgauge/gauge-dotnet/releases)
+Download the plugin from [Releases](https://github.com/getgauge/gauge-dotnet/releases)
+
 ```
-gauge install dotnet --file gauge-dotnet-0.5.0.zip
+gauge install dotnet --file gauge-dotnet-0.5.2.zip
 ```
 
 #### Build from Source
 
 ##### Requirements
-* [Dotnet Core](https://docs.microsoft.com/en-us/dotnet/core/index)
+* [.NET](https://learn.microsoft.com/en-us/dotnet/fundamentals/)
 * [Gauge](https://gauge.org/)
 * [JQ](https://stedolan.github.io/jq/) (for unix)
-
 
 Running `run.sh` or `run.cmd` should give the list of all tasks available. Below sections detail some commonly used tasks.
 
 ##### Compiling
 
-To build the project dlls:
+To build the project DLLs:
 
 ````
 ./run.cmd|./run.sh build
 ````
+
 ##### Testing
 
 After compiling
@@ -77,7 +77,7 @@ To run tests (unit and integration):
 
 ##### Installing
 
-To install the the dotnet plugin use(Note, this will uninstall gauge-dotnet before installing the compiled version):
+To install the dotnet plugin use (note, this will uninstall `gauge-dotnet` before installing the compiled version):
 
 ````
 ./run.cmd|./run.sh forceinstall
@@ -89,7 +89,7 @@ To install the the dotnet plugin use(Note, this will uninstall gauge-dotnet befo
 ./run.cmd|./run.sh package
 ````
 
-New distribution details need to be updated in the dotnet-install.json file in  [gauge plugin repository](https://github.com/getgauge/gauge-repository) for a new verison update.
+New distribution details need to be updated in the `dotnet-install.json` file in the [gauge plugin repository](https://github.com/getgauge/gauge-repository) for a new version update.
 
 ## License
 

--- a/src/Gauge.Dotnet.csproj
+++ b/src/Gauge.Dotnet.csproj
@@ -5,7 +5,7 @@
     <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
     <PackageId>Runner.NetCore30</PackageId>
     <Authors>The Gauge Team</Authors>
-    <Version>0.5.1</Version>
+    <Version>0.5.2</Version>
     <Company>ThoughtWorks Inc.</Company>
     <Product>Gauge</Product>
     <Description>C# runner for Gauge. https://gauge.org</Description>

--- a/src/GaugeProjectBuilder.cs
+++ b/src/GaugeProjectBuilder.cs
@@ -27,7 +27,7 @@ namespace Gauge.Dotnet
             }
 
             var configurationEnvVariable = ReadBuildConfiguration();
-            var commandArgs = $"publish --runtime={runtime} --configuration={configurationEnvVariable} --output=\"{gaugeBinDir}\" {additionalBuildArgs}";
+            var commandArgs = $"publish --runtime={runtime} --no-self-contained --configuration={configurationEnvVariable} --output=\"{gaugeBinDir}\" {additionalBuildArgs}";
 
             if (!string.IsNullOrEmpty(csprojEnvVariable))
             {

--- a/src/Program.cs
+++ b/src/Program.cs
@@ -7,6 +7,7 @@
 
 using System;
 using System.Diagnostics;
+using System.Threading.Tasks;
 
 namespace Gauge.Dotnet
 {
@@ -14,7 +15,7 @@ namespace Gauge.Dotnet
     {
         [STAThread]
         [DebuggerHidden]
-        private static void Main(string[] args)
+        private static async Task Main(string[] args)
         {
             if (args.Length == 0)
             {
@@ -24,7 +25,7 @@ namespace Gauge.Dotnet
 
             var phase = args[0];
             var command = GaugeCommandFactory.GetExecutor(phase);
-            command.Execute();
+            await command.Execute();
         }
     }
 }

--- a/src/dotnet.json
+++ b/src/dotnet.json
@@ -1,6 +1,6 @@
 {
   "id": "dotnet",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "description": "C# support for gauge + .NET 6.0/7.0 ",
   "run": {
     "windows": [


### PR DESCRIPTION
This PR resolves the "Failed to start gauge API: Timed out connecting to dotnet" intermittent error described in #196. 

It also resolves build warning NETSDK1179 during compilation of the target project.

Additionally it includes some minor doco updates to the README.