### PR TITLE
Make it optional for Gauge to load referenced assemblies in a project.

### DIFF
--- a/integration-test/ExecuteStepProcessorTests.cs
+++ b/integration-test/ExecuteStepProcessorTests.cs
@@ -12,6 +12,7 @@ using Gauge.Dotnet.Processors;
 using Gauge.Dotnet.Registries;
 using Gauge.Dotnet.Wrappers;
 using Gauge.Messages;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 
@@ -30,7 +31,7 @@ public class ExecuteStepProcessorTests : IntegrationTestsBase
         var assemblyLocater = new AssemblyLocater(_fileProvider, _loggerFactory.CreateLogger<AssemblyLocater>());
         var gaugeLoadContext = new GaugeLoadContext(assemblyLocater, _loggerFactory.CreateLogger<GaugeLoadContext>());
         var assemblyLoader = new AssemblyLoader(assemblyLocater, gaugeLoadContext, reflectionWrapper, activatorWrapper, new StepRegistry(),
-            _loggerFactory.CreateLogger<AssemblyLoader>());
+            _loggerFactory.CreateLogger<AssemblyLoader>(), _configuration);
         var dataStoreFactory = new DataStoreFactory(assemblyLoader, activatorWrapper);
         var tableFormatter = new TableFormatter(assemblyLoader, activatorWrapper);
         var executionInfoMapper = new ExecutionInfoMapper(assemblyLoader, activatorWrapper, dataStoreFactory, tableFormatter);
@@ -88,7 +89,7 @@ public class ExecuteStepProcessorTests : IntegrationTestsBase
         var assemblyLocater = new AssemblyLocater(_fileProvider, _loggerFactory.CreateLogger<AssemblyLocater>());
         var gaugeLoadContext = new GaugeLoadContext(assemblyLocater, _loggerFactory.CreateLogger<GaugeLoadContext>());
         var assemblyLoader = new AssemblyLoader(assemblyLocater, gaugeLoadContext, reflectionWrapper,
-            activatorWrapper, new StepRegistry(), _loggerFactory.CreateLogger<AssemblyLoader>());
+            activatorWrapper, new StepRegistry(), _loggerFactory.CreateLogger<AssemblyLoader>(), _configuration);
         var hookRegistry = new HookRegistry(assemblyLoader);
         var dataStoreFactory = new DataStoreFactory(assemblyLoader, activatorWrapper);
         var tableFormatter = new TableFormatter(assemblyLoader, activatorWrapper);

--- a/integration-test/ExecutionOrchestratorTests.cs
+++ b/integration-test/ExecutionOrchestratorTests.cs
@@ -29,7 +29,7 @@ public class ExecutionOrchestratorTests : IntegrationTestsBase
         var assemblyLocater = new AssemblyLocater(_fileProvider, _loggerFactory.CreateLogger<AssemblyLocater>());
         var gaugeLoadContext = new GaugeLoadContext(assemblyLocater, _loggerFactory.CreateLogger<GaugeLoadContext>());
         var assemblyLoader = new AssemblyLoader(assemblyLocater, gaugeLoadContext, reflectionWrapper,
-            activatorWrapper, new StepRegistry(), _loggerFactory.CreateLogger<AssemblyLoader>());
+            activatorWrapper, new StepRegistry(), _loggerFactory.CreateLogger<AssemblyLoader>(), _configuration);
         var hookRegistry = new HookRegistry(assemblyLoader);
         var dataStoreFactory = new DataStoreFactory(assemblyLoader, activatorWrapper);
         var tableFormatter = new TableFormatter(assemblyLoader, activatorWrapper);
@@ -54,7 +54,7 @@ public class ExecutionOrchestratorTests : IntegrationTestsBase
         var assemblyLocater = new AssemblyLocater(_fileProvider, _loggerFactory.CreateLogger<AssemblyLocater>());
         var gaugeLoadContext = new GaugeLoadContext(assemblyLocater, _loggerFactory.CreateLogger<GaugeLoadContext>());
         var assemblyLoader = new AssemblyLoader(assemblyLocater, gaugeLoadContext, reflectionWrapper,
-            activatorWrapper, new StepRegistry(), _loggerFactory.CreateLogger<AssemblyLoader>());
+            activatorWrapper, new StepRegistry(), _loggerFactory.CreateLogger<AssemblyLoader>(), _configuration);
         var hookRegistry = new HookRegistry(assemblyLoader);
         var dataStoreFactory = new DataStoreFactory(assemblyLoader, activatorWrapper);
         var tableFormatter = new TableFormatter(assemblyLoader, activatorWrapper);
@@ -81,7 +81,7 @@ public class ExecutionOrchestratorTests : IntegrationTestsBase
         var assemblyLocater = new AssemblyLocater(_fileProvider, _loggerFactory.CreateLogger<AssemblyLocater>());
         var gaugeLoadContext = new GaugeLoadContext(assemblyLocater, _loggerFactory.CreateLogger<GaugeLoadContext>());
         var assemblyLoader = new AssemblyLoader(assemblyLocater, gaugeLoadContext, reflectionWrapper,
-            activatorWrapper, new StepRegistry(), _loggerFactory.CreateLogger<AssemblyLoader>());
+            activatorWrapper, new StepRegistry(), _loggerFactory.CreateLogger<AssemblyLoader>(), _configuration);
         var hookRegistry = new HookRegistry(assemblyLoader);
         var dataStoreFactory = new DataStoreFactory(assemblyLoader, activatorWrapper);
         var tableFormatter = new TableFormatter(assemblyLoader, activatorWrapper);
@@ -107,7 +107,7 @@ public class ExecutionOrchestratorTests : IntegrationTestsBase
         var assemblyLocater = new AssemblyLocater(_fileProvider, _loggerFactory.CreateLogger<AssemblyLocater>());
         var gaugeLoadContext = new GaugeLoadContext(assemblyLocater, _loggerFactory.CreateLogger<GaugeLoadContext>());
         var assemblyLoader = new AssemblyLoader(assemblyLocater, gaugeLoadContext, reflectionWrapper,
-            activatorWrapper, new StepRegistry(), _loggerFactory.CreateLogger<AssemblyLoader>());
+            activatorWrapper, new StepRegistry(), _loggerFactory.CreateLogger<AssemblyLoader>(), _configuration);
         var hookRegistry = new HookRegistry(assemblyLoader);
         var dataStoreFactory = new DataStoreFactory(assemblyLoader, activatorWrapper);
         var tableFormatter = new TableFormatter(assemblyLoader, activatorWrapper);
@@ -134,7 +134,7 @@ public class ExecutionOrchestratorTests : IntegrationTestsBase
         var assemblyLocater = new AssemblyLocater(_fileProvider, _loggerFactory.CreateLogger<AssemblyLocater>());
         var gaugeLoadContext = new GaugeLoadContext(assemblyLocater, _loggerFactory.CreateLogger<GaugeLoadContext>());
         var assemblyLoader = new AssemblyLoader(assemblyLocater, gaugeLoadContext, reflectionWrapper,
-            activatorWrapper, new StepRegistry(), _loggerFactory.CreateLogger<AssemblyLoader>());
+            activatorWrapper, new StepRegistry(), _loggerFactory.CreateLogger<AssemblyLoader>(), _configuration);
         var hookRegistry = new HookRegistry(assemblyLoader);
         var dataStoreFactory = new DataStoreFactory(assemblyLoader, activatorWrapper);
         var tableFormatter = new TableFormatter(assemblyLoader, activatorWrapper);
@@ -161,7 +161,7 @@ public class ExecutionOrchestratorTests : IntegrationTestsBase
         var assemblyLocater = new AssemblyLocater(_fileProvider, _loggerFactory.CreateLogger<AssemblyLocater>());
         var gaugeLoadContext = new GaugeLoadContext(assemblyLocater, _loggerFactory.CreateLogger<GaugeLoadContext>());
         var assemblyLoader = new AssemblyLoader(assemblyLocater, gaugeLoadContext, reflectionWrapper,
-            activatorWrapper, new StepRegistry(), _loggerFactory.CreateLogger<AssemblyLoader>());
+            activatorWrapper, new StepRegistry(), _loggerFactory.CreateLogger<AssemblyLoader>(), _configuration);
         var registry = assemblyLoader.GetStepRegistry();
         var gaugeMethod = registry.MethodFor("and an alias");
         var stepTexts = gaugeMethod.Aliases.ToList();
@@ -180,7 +180,7 @@ public class ExecutionOrchestratorTests : IntegrationTestsBase
         var assemblyLocater = new AssemblyLocater(_fileProvider, _loggerFactory.CreateLogger<AssemblyLocater>());
         var gaugeLoadContext = new GaugeLoadContext(assemblyLocater, _loggerFactory.CreateLogger<GaugeLoadContext>());
         var assemblyLoader = new AssemblyLoader(assemblyLocater, gaugeLoadContext, reflectionWrapper,
-            activatorWrapper, new StepRegistry(), _loggerFactory.CreateLogger<AssemblyLoader>());
+            activatorWrapper, new StepRegistry(), _loggerFactory.CreateLogger<AssemblyLoader>(), _configuration);
         var hookRegistry = new HookRegistry(assemblyLoader);
         var dataStoreFactory = new DataStoreFactory(assemblyLoader, activatorWrapper);
         var tableFormatter = new TableFormatter(assemblyLoader, activatorWrapper);
@@ -209,7 +209,7 @@ public class ExecutionOrchestratorTests : IntegrationTestsBase
         var assemblyLocater = new AssemblyLocater(_fileProvider, _loggerFactory.CreateLogger<AssemblyLocater>());
         var gaugeLoadContext = new GaugeLoadContext(assemblyLocater, _loggerFactory.CreateLogger<GaugeLoadContext>());
         var assemblyLoader = new AssemblyLoader(assemblyLocater, gaugeLoadContext, reflectionWrapper,
-            activatorWrapper, new StepRegistry(), _loggerFactory.CreateLogger<AssemblyLoader>());
+            activatorWrapper, new StepRegistry(), _loggerFactory.CreateLogger<AssemblyLoader>(), _configuration);
         var hookRegistry = new HookRegistry(assemblyLoader);
         var dataStoreFactory = new DataStoreFactory(assemblyLoader, activatorWrapper);
         var tableFormatter = new TableFormatter(assemblyLoader, activatorWrapper);

--- a/integration-test/ExternalReferenceTests.cs
+++ b/integration-test/ExternalReferenceTests.cs
@@ -38,7 +38,7 @@ public class ExternalReferenceTests
         var assemblyLocater = new AssemblyLocater(fileProvider, _loggerFactory.CreateLogger<AssemblyLocater>());
         var gaugeLoadContext = new GaugeLoadContext(assemblyLocater, _loggerFactory.CreateLogger<GaugeLoadContext>());
         var assemblyLoader = new AssemblyLoader(assemblyLocater, gaugeLoadContext, new ReflectionWrapper(),
-            new ActivatorWrapper(serviceProvider), new StepRegistry(), _loggerFactory.CreateLogger<AssemblyLoader>());
+            new ActivatorWrapper(serviceProvider), new StepRegistry(), _loggerFactory.CreateLogger<AssemblyLoader>(), config);
 
         var stepValidationProcessor = new StepValidationProcessor(assemblyLoader.GetStepRegistry());
         var message = new StepValidateRequest
@@ -70,7 +70,7 @@ public class ExternalReferenceTests
         var assemblyLocater = new AssemblyLocater(fileProvider, _loggerFactory.CreateLogger<AssemblyLocater>());
         var gaugeLoadContext = new GaugeLoadContext(assemblyLocater, _loggerFactory.CreateLogger<GaugeLoadContext>());
         var assemblyLoader = new AssemblyLoader(assemblyLocater, gaugeLoadContext, reflectionWrapper,
-            activatorWrapper, new StepRegistry(), _loggerFactory.CreateLogger<AssemblyLoader>());
+            activatorWrapper, new StepRegistry(), _loggerFactory.CreateLogger<AssemblyLoader>(), config);
         var hookRegistry = new HookRegistry(assemblyLoader);
         var dataStoreFactory = new DataStoreFactory(assemblyLoader, activatorWrapper);
         var tableFormatter = new TableFormatter(assemblyLoader, activatorWrapper);

--- a/src/Extensions/ConfigurationExtensions.cs
+++ b/src/Extensions/ConfigurationExtensions.cs
@@ -44,6 +44,11 @@ public static class ConfigurationExtensions
     public static string GetGaugeExcludeDirs(this IConfiguration config) =>
         config.GetValue<string>("GAUGE_EXCLUDE_DIRS");
 
+    // Controls if assemblies referenced by the test project should be loaded into Gauge context
+    // NOTE: If not needed, disabling this may decrease the time it takes to initialize Gauge
+    public static string GetGaugeCSharpLoadReferencedAssemblies(this IConfiguration config) =>
+        config.GetValue<string>("GAUGE_CSHARP_LOAD_REFERENCED_ASSEMBLIES") ?? "true";
+
     public static string GetGaugeBinDir(this IConfiguration config)
     {
         var customBuildPath = config.GetValue<string>("GAUGE_CUSTOM_BUILD_PATH");

--- a/src/Gauge.Dotnet.csproj
+++ b/src/Gauge.Dotnet.csproj
@@ -6,7 +6,7 @@
 		<ImplicitUsings>enable</ImplicitUsings>
 		<PackageId>Runner.NetCore30</PackageId>
 		<Authors>The Gauge Team</Authors>
-		<Version>0.7.4</Version>
+		<Version>0.7.5</Version>
 		<Company>ThoughtWorks Inc.</Company>
 		<Product>Gauge</Product>
 		<Description>C# runner for Gauge. https://gauge.org</Description>

--- a/src/dotnet.json
+++ b/src/dotnet.json
@@ -1,6 +1,6 @@
 {
   "id": "dotnet",
-  "version": "0.7.4",
+  "version": "0.7.5",
   "description": "C# support for gauge + .NET",
   "run": {
     "windows": [


### PR DESCRIPTION
@sriv 
@mpekurny 

Any thoughts/input about this?

Regarding: https://github.com/getgauge/gauge/issues/1856
Error occurs when the runner_connection_timeout occurs, which happens when the dotnet runner takes too long time to load the project. I increased my timeout, but it took around 70 seconds from opening a project until Gauge was ready to run a spec which as frustrating!

After looking in the lsp.log the conclusion is that Gauge loads a lot (in my case) not needed assemblies and that is a very slow process. See log below, it took 51 seconds to load them and I have rather decent laptop/workstation.

The runner loads all assemblies referenced by my test framework/project. I guess this might be needed if you import Gauge code (steps etc) as a dependency into your project, but in my case it makes no sense?

Therefore, I propose to make the loading of referenced assemblies optional via env. properties.

![bild](https://github.com/user-attachments/assets/5b4f9788-0406-4512-8d05-c10eb8633bae)

If missing the property Gauge defaults to true, so works as before in that case. It's essentially only an if-statement in the assembly-loader and the introduction of a new property.

This made a huge impact on loading times.

Also realized that the code accesses an assembly’s ExportedTypes property, and then resolves all public types defined in that assembly. This resolution triggered loading of additional dependent assemblies exposed through those types. This could be mitigated by changing most to 'internal' instead of 'public' in my own project, since there is no actual need for most of my classes/interfaces to be public. This was not the big issue, but a final optimization in my project. 

Viola! The runner now loaded the needed assemblies in 1 second instead of >50 and I could run a spec 20 seconds after opening the project in VSC instead of 70 seconds.

Log before change, all this was loaded after my project dll almost everything could be skipped (see timestamps):

```
3-02-2025 00:28:13.259 [dotnet] [DEBUG] Try load System.Runtime in LockFreeGaugeLoadContext
13-02-2025 00:28:13.259 [dotnet] [DEBUG] Try load Serilog in LockFreeGaugeLoadContext
13-02-2025 00:28:13.419 [dotnet] [DEBUG] Try load Microsoft.Playwright in LockFreeGaugeLoadContext
13-02-2025 00:28:21.350 [dotnet] [DEBUG] Try load System.Collections in LockFreeGaugeLoadContext
13-02-2025 00:28:21.350 [dotnet] [DEBUG] Try load RestSharp in LockFreeGaugeLoadContext
13-02-2025 00:28:21.686 [dotnet] [DEBUG] Try load Newtonsoft.Json in LockFreeGaugeLoadContext
13-02-2025 00:28:25.211 [dotnet] [DEBUG] Try load System.Linq.Expressions in LockFreeGaugeLoadContext
13-02-2025 00:28:25.212 [dotnet] [DEBUG] Try load WebDriver in LockFreeGaugeLoadContext
13-02-2025 00:28:30.162 [dotnet] [DEBUG] Try load System.Net.WebSockets.Client in LockFreeGaugeLoadContext
13-02-2025 00:28:30.164 [dotnet] [DEBUG] Try load System.Net.WebSockets in LockFreeGaugeLoadContext
13-02-2025 00:28:30.167 [dotnet] [DEBUG] Try load System.Net.Http in LockFreeGaugeLoadContext
13-02-2025 00:28:30.167 [dotnet] [DEBUG] Try load System.Diagnostics.Process in LockFreeGaugeLoadContext
13-02-2025 00:28:30.167 [dotnet] [DEBUG] Try load System.Threading.Thread in LockFreeGaugeLoadContext
13-02-2025 00:28:30.167 [dotnet] [DEBUG] Try load Renci.SshNet in LockFreeGaugeLoadContext
13-02-2025 00:28:34.348 [dotnet] [DEBUG] Try load System.Linq in LockFreeGaugeLoadContext
13-02-2025 00:28:34.348 [dotnet] [DEBUG] Try load System.Text.RegularExpressions in LockFreeGaugeLoadContext
13-02-2025 00:28:34.348 [dotnet] [DEBUG] Try load System.Drawing.Primitives in LockFreeGaugeLoadContext
13-02-2025 00:28:34.349 [dotnet] [DEBUG] Try load System.Net.Sockets in LockFreeGaugeLoadContext
13-02-2025 00:28:34.349 [dotnet] [DEBUG] Try load System.Net.Primitives in LockFreeGaugeLoadContext
13-02-2025 00:28:34.349 [dotnet] [DEBUG] Try load SixLabors.ImageSharp in LockFreeGaugeLoadContext
13-02-2025 00:28:39.826 [dotnet] [DEBUG] Try load FluentAssertions in LockFreeGaugeLoadContext
13-02-2025 00:28:43.319 [dotnet] [DEBUG] Try load Serilog.Sinks.Elasticsearch in LockFreeGaugeLoadContext
13-02-2025 00:28:43.387 [dotnet] [DEBUG] Try load System.Security.Cryptography in LockFreeGaugeLoadContext
13-02-2025 00:28:43.388 [dotnet] [DEBUG] Try load Elasticsearch.Net in LockFreeGaugeLoadContext
13-02-2025 00:28:49.856 [dotnet] [DEBUG] Try load Microsoft.Extensions.Configuration.Abstractions in LockFreeGaugeLoadContext
13-02-2025 00:28:49.869 [dotnet] [DEBUG] Try load nunit.framework in LockFreeGaugeLoadContext
13-02-2025 00:28:51.159 [dotnet] [DEBUG] Try load Appium.Net in LockFreeGaugeLoadContext
13-02-2025 00:28:51.261 [dotnet] [DEBUG] Try load MySql.Data in LockFreeGaugeLoadContext
13-02-2025 00:28:57.662 [dotnet] [DEBUG] Try load DapperQueryBuilder.StrongName in LockFreeGaugeLoadContext
13-02-2025 00:28:57.679 [dotnet] [DEBUG] Try load System.Data.Common in LockFreeGaugeLoadContext
13-02-2025 00:28:57.680 [dotnet] [DEBUG] Try load System.Runtime.Serialization.Primitives in LockFreeGaugeLoadContext
13-02-2025 00:28:57.681 [dotnet] [DEBUG] Try load System.ComponentModel.Annotations in LockFreeGaugeLoadContext
13-02-2025 00:28:57.683 [dotnet] [DEBUG] Try load System.Net.Requests in LockFreeGaugeLoadContext
13-02-2025 00:28:57.684 [dotnet] [DEBUG] Try load System.Text.Json in LockFreeGaugeLoadContext
13-02-2025 00:28:57.684 [dotnet] [DEBUG] Try load Microsoft.CSharp in LockFreeGaugeLoadContext
13-02-2025 00:28:57.688 [dotnet] [DEBUG] Try load AngleSharp in LockFreeGaugeLoadContext
13-02-2025 00:29:02.836 [dotnet] [DEBUG] Try load Percy in LockFreeGaugeLoadContext
13-02-2025 00:29:02.847 [dotnet] [DEBUG] Try load System.Threading in LockFreeGaugeLoadContext
13-02-2025 00:29:02.847 [dotnet] [DEBUG] Try load Humanizer in LockFreeGaugeLoadContext
13-02-2025 00:29:03.607 [dotnet] [DEBUG] Try load org.matheval in LockFreeGaugeLoadContext
13-02-2025 00:29:03.638 [dotnet] [DEBUG] Try load System.ComponentModel.Primitives in LockFreeGaugeLoadContext
13-02-2025 00:29:03.638 [dotnet] [DEBUG] Try load Codeuctivity.ImageSharpCompare in LockFreeGaugeLoadContext
13-02-2025 00:29:03.641 [dotnet] [DEBUG] Try load System.Console in LockFreeGaugeLoadContext
13-02-2025 00:29:03.641 [dotnet] [DEBUG] Try load Microsoft.Extensions.Configuration in LockFreeGaugeLoadContext
13-02-2025 00:29:03.656 [dotnet] [DEBUG] Try load Microsoft.Extensions.Configuration.FileExtensions in LockFreeGaugeLoadContext
13-02-2025 00:29:03.663 [dotnet] [DEBUG] Try load Microsoft.Extensions.Configuration.Json in LockFreeGaugeLoadContext
13-02-2025 00:29:03.670 [dotnet] [DEBUG] Try load Serilog.Settings.Configuration in LockFreeGaugeLoadContext
13-02-2025 00:29:03.699 [dotnet] [DEBUG] Try load YamlDotNet in LockFreeGaugeLoadContext
13-02-2025 00:29:04.212 [dotnet] [DEBUG] Try load InterpolatedSql in LockFreeGaugeLoadContext
13-02-2025 00:29:04.238 [dotnet] [DEBUG] Try load WebDriverManager in LockFreeGaugeLoadContext
13-02-2025 00:29:04.250 [dotnet] [DEBUG] Try load System.Collections.Specialized in LockFreeGaugeLoadContext
13-02-2025 00:29:04.251 [dotnet] [DEBUG] Try load WebDriver.Support in LockFreeGaugeLoadContext
13-02-2025 00:29:04.267 [dotnet] [DEBUG] Try load System.Runtime in LockFreeGaugeLoadContext
13-02-2025 00:29:04.267 [dotnet] [DEBUG] Try load System.Collections in LockFreeGaugeLoadContext
13-02-2025 00:29:04.267 [dotnet] [DEBUG] Try load System.Runtime in LockFreeGaugeLoadContext
13-02-2025 00:29:04.268 [dotnet] [DEBUG] Try load System.Net.Http in LockFreeGaugeLoadContext
13-02-2025 00:29:04.269 [dotnet] [DEBUG] Try load System.Runtime in LockFreeGaugeLoadContext
13-02-2025 00:29:04.269 [dotnet] [DEBUG] Try load System.Collections in LockFreeGaugeLoadContext
13-02-2025 00:29:04.269 [dotnet] [DEBUG] Try load netstandard in LockFreeGaugeLoadContext
13-02-2025 00:29:04.270 [dotnet] [DEBUG] Try load System.Drawing.Primitives in LockFreeGaugeLoadContext
13-02-2025 00:29:04.274 [dotnet] [DEBUG] Try load System.Runtime in LockFreeGaugeLoadContext
13-02-2025 00:29:04.274 [dotnet] [DEBUG] Try load System.Collections in LockFreeGaugeLoadContext
```

After adding the configuration parameter to the assembly-loader (and doing some classes/interfaces 'internal' in my project):
```
13-02-2025 10:26:08.041 [dotnet] [DEBUG] Try load System.Runtime in LockFreeGaugeLoadContext
13-02-2025 10:26:08.043 [dotnet] [DEBUG] Number of AssembliesReferencingGaugeLib : 1
13-02-2025 10:26:08.045 [dotnet] [DEBUG] Try load System.Runtime in LockFreeGaugeLoadContext
13-02-2025 10:26:08.045 [dotnet] [DEBUG] Try load System.Collections in LockFreeGaugeLoadContext
13-02-2025 10:26:08.046 [dotnet] [DEBUG] Building StepRegistry...
13-02-2025 10:26:08.050 [dotnet] [DEBUG] Try load System.Net.Http in LockFreeGaugeLoadContext
13-02-2025 10:26:08.052 [dotnet] [DEBUG] Try load System.Collections in LockFreeGaugeLoadContext
```

I believe this possibility to limit the assembly-loader to be significant enough for a PR.

Best regards,

