### PR TITLE
Guards all StepRegistry mutations to make them thread-safe.

### DIFF
--- a/integration-test/ExecutionOrchestratorTests.cs
+++ b/integration-test/ExecutionOrchestratorTests.cs
@@ -39,7 +39,7 @@ public class ExecutionOrchestratorTests : IntegrationTestsBase
             new StepExecutor(assemblyLoader, _loggerFactory.CreateLogger<StepExecutor>(), executionInfoMapper), _configuration,
             _loggerFactory.CreateLogger<ExecutionOrchestrator>(), dataStoreFactory);
         var gaugeMethod = assemblyLoader.GetStepRegistry()
-            .MethodFor("I throw a serializable exception and continue");
+            .LookupStep("I throw a serializable exception and continue").Methods[0];
         var executionResult = await orchestrator.ExecuteStep(gaugeMethod, 1);
         ClassicAssert.IsTrue(executionResult.Failed);
         ClassicAssert.IsTrue(executionResult.RecoverableError);
@@ -63,7 +63,7 @@ public class ExecutionOrchestratorTests : IntegrationTestsBase
             new HookExecutor(assemblyLoader, executionInfoMapper, hookRegistry, _loggerFactory.CreateLogger<HookExecutor>()),
             new StepExecutor(assemblyLoader, _loggerFactory.CreateLogger<StepExecutor>(), executionInfoMapper), _configuration,
             _loggerFactory.CreateLogger<ExecutionOrchestrator>(), dataStoreFactory);
-        var gaugeMethod = assemblyLoader.GetStepRegistry().MethodFor("Step that takes a table {}");
+        var gaugeMethod = assemblyLoader.GetStepRegistry().LookupStep("Step that takes a table {}").Methods[0];
         var table = new Table(new List<string> { "foo", "bar" });
         table.AddRow(new List<string> { "foorow1", "barrow1" });
         table.AddRow(new List<string> { "foorow2", "barrow2" });
@@ -91,7 +91,7 @@ public class ExecutionOrchestratorTests : IntegrationTestsBase
             new StepExecutor(assemblyLoader, _loggerFactory.CreateLogger<StepExecutor>(), executionInfoMapper), _configuration,
             _loggerFactory.CreateLogger<ExecutionOrchestrator>(), dataStoreFactory);
         var gaugeMethod = assemblyLoader.GetStepRegistry()
-            .MethodFor("A context step which gets executed before every scenario");
+            .LookupStep("A context step which gets executed before every scenario").Methods[0];
 
         var executionResult = await orchestrator.ExecuteStep(gaugeMethod, 1);
         ClassicAssert.False(executionResult.Failed);
@@ -117,7 +117,7 @@ public class ExecutionOrchestratorTests : IntegrationTestsBase
             new StepExecutor(assemblyLoader, _loggerFactory.CreateLogger<StepExecutor>(), executionInfoMapper), _configuration,
             _loggerFactory.CreateLogger<ExecutionOrchestrator>(), dataStoreFactory);
 
-        var gaugeMethod = assemblyLoader.GetStepRegistry().MethodFor("Say {} to {}");
+        var gaugeMethod = assemblyLoader.GetStepRegistry().LookupStep("Say {} to {}").Methods[0];
 
         var executionResult = await executionOrchestrator.ExecuteStep(gaugeMethod, 1, "hello", "world");
 
@@ -144,7 +144,7 @@ public class ExecutionOrchestratorTests : IntegrationTestsBase
             new StepExecutor(assemblyLoader, _loggerFactory.CreateLogger<StepExecutor>(), executionInfoMapper), _configuration,
             _loggerFactory.CreateLogger<ExecutionOrchestrator>(), dataStoreFactory);
 
-        var gaugeMethod = assemblyLoader.GetStepRegistry().MethodFor("I throw an AggregateException");
+        var gaugeMethod = assemblyLoader.GetStepRegistry().LookupStep("I throw an AggregateException").Methods[0];
         var executionResult = await executionOrchestrator.ExecuteStep(gaugeMethod, 1);
 
         ClassicAssert.True(executionResult.Failed);
@@ -163,7 +163,7 @@ public class ExecutionOrchestratorTests : IntegrationTestsBase
         var assemblyLoader = new AssemblyLoader(assemblyLocater, gaugeLoadContext, reflectionWrapper,
             activatorWrapper, new StepRegistry(), _loggerFactory.CreateLogger<AssemblyLoader>(), _configuration);
         var registry = assemblyLoader.GetStepRegistry();
-        var gaugeMethod = registry.MethodFor("and an alias");
+        var gaugeMethod = registry.LookupStep("and an alias").Methods[0];
         var stepTexts = gaugeMethod.Aliases.ToList();
 
         ClassicAssert.Contains("Step with text", stepTexts);
@@ -189,7 +189,7 @@ public class ExecutionOrchestratorTests : IntegrationTestsBase
             new HookExecutor(assemblyLoader, executionInfoMapper, hookRegistry, _loggerFactory.CreateLogger<HookExecutor>()),
             new StepExecutor(assemblyLoader, _loggerFactory.CreateLogger<StepExecutor>(), executionInfoMapper), _configuration,
             _loggerFactory.CreateLogger<ExecutionOrchestrator>(), dataStoreFactory);
-        var gaugeMethod = assemblyLoader.GetStepRegistry().MethodFor("I throw a serializable exception");
+        var gaugeMethod = assemblyLoader.GetStepRegistry().LookupStep("I throw a serializable exception").Methods[0];
 
         var executionResult = await executionOrchestrator.ExecuteStep(gaugeMethod, 1);
 
@@ -219,7 +219,7 @@ public class ExecutionOrchestratorTests : IntegrationTestsBase
             new StepExecutor(assemblyLoader, _loggerFactory.CreateLogger<StepExecutor>(), executionInfoMapper), _configuration,
             _loggerFactory.CreateLogger<ExecutionOrchestrator>(), dataStoreFactory);
 
-        var gaugeMethod = assemblyLoader.GetStepRegistry().MethodFor("I throw an unserializable exception");
+        var gaugeMethod = assemblyLoader.GetStepRegistry().LookupStep("I throw an unserializable exception").Methods[0];
         var executionResult = await executionOrchestrator.ExecuteStep(gaugeMethod, 1);
         ClassicAssert.True(executionResult.Failed);
         ClassicAssert.AreEqual(expectedMessage, executionResult.ErrorMessage);

--- a/integration-test/ExternalReferenceTests.cs
+++ b/integration-test/ExternalReferenceTests.cs
@@ -40,7 +40,7 @@ public class ExternalReferenceTests
         var assemblyLoader = new AssemblyLoader(assemblyLocater, gaugeLoadContext, new ReflectionWrapper(),
             new ActivatorWrapper(serviceProvider), new StepRegistry(), _loggerFactory.CreateLogger<AssemblyLoader>(), config);
 
-        var stepValidationProcessor = new StepValidationProcessor(assemblyLoader.GetStepRegistry());
+        var stepValidationProcessor = new StepValidationProcessor(assemblyLoader.GetStepRegistry(), _loggerFactory.CreateLogger<StepValidationProcessor>());
         var message = new StepValidateRequest
         {
             StepText = stepText,

--- a/src/Gauge.Dotnet.csproj
+++ b/src/Gauge.Dotnet.csproj
@@ -6,7 +6,7 @@
 		<ImplicitUsings>enable</ImplicitUsings>
 		<PackageId>Gauge.Runner</PackageId>
 		<Authors>The Gauge Team</Authors>
-		<Version>0.7.6</Version>
+		<Version>0.7.7</Version>
 		<Company>ThoughtWorks Inc.</Company>
 		<Product>Gauge</Product>
 		<Description>C# runner for Gauge. https://gauge.org</Description>

--- a/src/Loaders/AssemblyLoader.cs
+++ b/src/Loaders/AssemblyLoader.cs
@@ -87,11 +87,13 @@ public class AssemblyLoader : IAssemblyLoader
             foreach (var stepText in stepTexts)
             {
                 var stepValue = GetStepValue(stepText);
-                if (_registry.ContainsStep(stepValue))
+                var lookup = _registry.LookupStep(stepValue);
+                if (lookup.Exists)
                 {
                     _logger.LogDebug("'{StepValue}': implementation found in StepRegistry, setting reflected methodInfo", stepValue);
-                    _registry.MethodFor(stepValue).MethodInfo = info;
-                    _registry.MethodFor(stepValue).ContinueOnFailure = info.IsRecoverableStep(this);
+                    var existing = lookup.Methods[0];
+                    existing.MethodInfo = info;
+                    existing.ContinueOnFailure = info.IsRecoverableStep(this);
                 }
                 else
                 {

--- a/src/Loaders/StaticLoader.cs
+++ b/src/Loaders/StaticLoader.cs
@@ -24,12 +24,6 @@ public sealed class StaticLoader : IStaticLoader
     private readonly IConfiguration _config;
     private readonly ILogger<StaticLoader> _logger;
 
-    // Guards all StepRegistry mutations. gRPC dispatches CacheFileRequest messages concurrently on separate threads,
-    // all sharing this singleton. Without synchronization, concurrent ReloadSteps calls can interleave their
-    // RemoveSteps/AddStep operations — one thread's dictionary rebuild overwrites another's, leaving stale entries
-    // that cause false "duplicate step implementation" warnings in the IDE.
-    private readonly object _registryLock = new object();
-
 
     public StaticLoader(IAttributesLoader attributesLoader, IDirectoryWrapper directoryWrapper, IConfiguration config, ILogger<StaticLoader> logger)
     {
@@ -50,29 +44,20 @@ public sealed class StaticLoader : IStaticLoader
 
     public void LoadStepsFromText(string content, string filepath)
     {
-        lock (_registryLock)
-        {
-            var steps = GetStepsFrom(content);
-            AddStepsToRegistry(filepath, steps);
-        }
+        var steps = GetStepsFrom(content);
+        var entries = BuildStepEntries(filepath, steps);
+        _stepRegistry.ReplaceSteps(filepath, entries);
     }
 
     public void ReloadSteps(string content, string filepath)
     {
         if (IsFileRemoved(filepath)) return;
-        lock (_registryLock)
-        {
-            _stepRegistry.RemoveSteps(filepath);
-            LoadStepsFromText(content, filepath);
-        }
+        LoadStepsFromText(content, filepath);
     }
 
     public void RemoveSteps(string file)
     {
-        lock (_registryLock)
-        {
-            _stepRegistry.RemoveSteps(file);
-        }
+        _stepRegistry.RemoveSteps(file);
     }
 
     private bool IsFileRemoved(string file)
@@ -109,8 +94,10 @@ public sealed class StaticLoader : IStaticLoader
         }
     }
 
-    private void AddStepsToRegistry(string fileName, IEnumerable<MethodDeclarationSyntax> stepMethods)
+    private static IReadOnlyList<(string stepValue, GaugeMethod method)> BuildStepEntries(
+        string fileName, IEnumerable<MethodDeclarationSyntax> stepMethods)
     {
+        var entries = new List<(string, GaugeMethod)>();
         foreach (var stepMethod in stepMethods)
         {
             var attributeListSyntax = stepMethod.AttributeLists.WithStepAttribute();
@@ -135,9 +122,10 @@ public sealed class StaticLoader : IStaticLoader
                     FileName = fileName,
                     IsExternal = false
                 };
-                _stepRegistry.AddStep(stepValue, entry);
+                entries.Add((stepValue, entry));
             }
         }
+        return entries;
     }
 
     private static IEnumerable<MethodDeclarationSyntax> GetStepsFrom(string content)

--- a/src/Loaders/StaticLoader.cs
+++ b/src/Loaders/StaticLoader.cs
@@ -24,6 +24,12 @@ public sealed class StaticLoader : IStaticLoader
     private readonly IConfiguration _config;
     private readonly ILogger<StaticLoader> _logger;
 
+    // Guards all StepRegistry mutations. gRPC dispatches CacheFileRequest messages concurrently on separate threads,
+    // all sharing this singleton. Without synchronization, concurrent ReloadSteps calls can interleave their
+    // RemoveSteps/AddStep operations — one thread's dictionary rebuild overwrites another's, leaving stale entries
+    // that cause false "duplicate step implementation" warnings in the IDE.
+    private readonly object _registryLock = new object();
+
 
     public StaticLoader(IAttributesLoader attributesLoader, IDirectoryWrapper directoryWrapper, IConfiguration config, ILogger<StaticLoader> logger)
     {
@@ -44,20 +50,29 @@ public sealed class StaticLoader : IStaticLoader
 
     public void LoadStepsFromText(string content, string filepath)
     {
-        var steps = GetStepsFrom(content);
-        AddStepsToRegistry(filepath, steps);
+        lock (_registryLock)
+        {
+            var steps = GetStepsFrom(content);
+            AddStepsToRegistry(filepath, steps);
+        }
     }
 
     public void ReloadSteps(string content, string filepath)
     {
         if (IsFileRemoved(filepath)) return;
-        _stepRegistry.RemoveSteps(filepath);
-        LoadStepsFromText(content, filepath);
+        lock (_registryLock)
+        {
+            _stepRegistry.RemoveSteps(filepath);
+            LoadStepsFromText(content, filepath);
+        }
     }
 
     public void RemoveSteps(string file)
     {
-        _stepRegistry.RemoveSteps(file);
+        lock (_registryLock)
+        {
+            _stepRegistry.RemoveSteps(file);
+        }
     }
 
     private bool IsFileRemoved(string file)

--- a/src/Processors/ExecuteStepProcessor.cs
+++ b/src/Processors/ExecuteStepProcessor.cs
@@ -29,10 +29,11 @@ public class ExecuteStepProcessor : IGaugeProcessor<ExecuteStepRequest, Executio
     [DebuggerHidden]
     public async Task<ExecutionStatusResponse> Process(int streamId, ExecuteStepRequest request)
     {
-        if (!_stepRegistry.ContainsStep(request.ParsedStepText))
+        var lookup = _stepRegistry.LookupStep(request.ParsedStepText);
+        if (!lookup.Exists)
             return ExecutionError("Step Implementation not found");
 
-        var method = _stepRegistry.MethodFor(request.ParsedStepText);
+        var method = lookup.Methods[0];
 
         var parameters = method.ParameterCount;
         var args = new string[parameters];

--- a/src/Processors/RefactorProcessor.cs
+++ b/src/Processors/RefactorProcessor.cs
@@ -85,9 +85,13 @@ public class RefactorProcessor : IGaugeProcessor<RefactorRequest, RefactorRespon
 
     private GaugeMethod GetGaugeMethod(ProtoStepValue stepValue)
     {
-        if (_stepRegistry.HasMultipleImplementations(stepValue.StepValue))
+        var lookup = _stepRegistry.LookupStep(stepValue.StepValue);
+        if (!lookup.Exists)
+            throw new Exception(string.Format("Step implementation not found for : {0}",
+                stepValue.ParameterizedStepValue));
+        if (lookup.HasMultipleImplementations)
             throw new Exception(string.Format("Multiple step implementations found for : {0}",
                 stepValue.ParameterizedStepValue));
-        return _stepRegistry.MethodFor(stepValue.StepValue);
+        return lookup.Methods[0];
     }
 }

--- a/src/Processors/StepNameProcessor.cs
+++ b/src/Processors/StepNameProcessor.cs
@@ -24,19 +24,17 @@ public class StepNameProcessor : IGaugeProcessor<StepNameRequest, StepNameRespon
     {
 
         var parsedStepText = request.StepValue;
-        var isStepPresent = _stepRegistry.ContainsStep(parsedStepText);
+        var lookup = _stepRegistry.LookupStep(parsedStepText);
         var response = new StepNameResponse
         {
-            IsStepPresent = isStepPresent
+            IsStepPresent = lookup.Exists
         };
 
-        if (!isStepPresent) return Task.FromResult(response);
+        if (!lookup.Exists) return Task.FromResult(response);
 
-        var stepText = _stepRegistry.GetStepText(parsedStepText);
-        var hasAlias = _stepRegistry.HasAlias(stepText);
-        var info = _stepRegistry.MethodFor(parsedStepText);
+        var info = lookup.Methods[0];
         response.IsExternal = info.IsExternal;
-        response.HasAlias = hasAlias;
+        response.HasAlias = info.HasAlias;
         if (!response.IsExternal)
         {
             response.FileName = info.FileName;
@@ -49,10 +47,10 @@ public class StepNameProcessor : IGaugeProcessor<StepNameRequest, StepNameRespon
             };
         }
 
-        if (hasAlias)
+        if (info.HasAlias)
             response.StepName.AddRange(info.Aliases);
         else
-            response.StepName.Add(stepText);
+            response.StepName.Add(info.StepText);
 
         return Task.FromResult(response);
     }

--- a/src/Processors/StepValidationProcessor.cs
+++ b/src/Processors/StepValidationProcessor.cs
@@ -27,18 +27,19 @@ public class StepValidationProcessor : IGaugeProcessor<StepValidateRequest, Step
         var errorMessage = "";
         var suggestion = "";
         var errorType = StepValidateResponse.Types.ErrorType.StepImplementationNotFound;
-        if (!_stepRegistry.ContainsStep(stepToValidate))
+
+        var lookup = _stepRegistry.LookupStep(stepToValidate);
+        if (!lookup.Exists)
         {
             isValid = false;
             errorMessage = string.Format("No implementation found for : {0}. Full Step Text :", stepToValidate);
             suggestion = GetSuggestion(request.StepValue);
         }
-        else if (_stepRegistry.HasMultipleImplementations(stepToValidate))
+        else if (lookup.HasMultipleImplementations)
         {
             isValid = false;
             errorType = StepValidateResponse.Types.ErrorType.DuplicateStepImplementation;
-            var implementations = _stepRegistry.MethodsFor(stepToValidate);
-            var locations = string.Join("\n", implementations.Select(m =>
+            var locations = string.Join("\n", lookup.Methods.Select(m =>
                 $"  {m.ClassName}.{m.Name} in {m.FileName}:{m.Span.StartLinePosition.Line + 1}"));
             errorMessage = $"Step: {stepToValidate}\n{locations}";
         }

--- a/src/Processors/StepValidationProcessor.cs
+++ b/src/Processors/StepValidationProcessor.cs
@@ -37,7 +37,10 @@ public class StepValidationProcessor : IGaugeProcessor<StepValidateRequest, Step
         {
             isValid = false;
             errorType = StepValidateResponse.Types.ErrorType.DuplicateStepImplementation;
-            errorMessage = string.Format("Multiple step implementations found for : {0}", stepToValidate);
+            var implementations = _stepRegistry.MethodsFor(stepToValidate);
+            var locations = string.Join("\n", implementations.Select(m =>
+                $"  {m.ClassName}.{m.Name} in {m.FileName}:{m.Span.StartLinePosition.Line + 1}"));
+            errorMessage = $"Step: {stepToValidate}\n{locations}";
         }
         return Task.FromResult(GetStepValidateResponseMessage(isValid, errorType, errorMessage, suggestion));
     }

--- a/src/Processors/StepValidationProcessor.cs
+++ b/src/Processors/StepValidationProcessor.cs
@@ -8,16 +8,19 @@
 using Gauge.Dotnet.Extensions;
 using Gauge.Dotnet.Registries;
 using Gauge.Messages;
+using Microsoft.Extensions.Logging;
 
 namespace Gauge.Dotnet.Processors;
 
 public class StepValidationProcessor : IGaugeProcessor<StepValidateRequest, StepValidateResponse>
 {
     private readonly IStepRegistry _stepRegistry;
+    private readonly ILogger<StepValidationProcessor> _logger;
 
-    public StepValidationProcessor(IStepRegistry stepRegistry)
+    public StepValidationProcessor(IStepRegistry stepRegistry, ILogger<StepValidationProcessor> logger)
     {
         _stepRegistry = stepRegistry;
+        _logger = logger;
     }
 
     public Task<StepValidateResponse> Process(int stream, StepValidateRequest request)
@@ -42,6 +45,12 @@ public class StepValidationProcessor : IGaugeProcessor<StepValidateRequest, Step
             var locations = string.Join("\n", lookup.Methods.Select(m =>
                 $"  {m.ClassName}.{m.Name} in {m.FileName}:{m.Span.StartLinePosition.Line + 1}"));
             errorMessage = $"Step: {stepToValidate}\n{locations}";
+            _logger.LogDebug("Duplicate step implementation found for: {StepText}", stepToValidate);
+            foreach (var m in lookup.Methods)
+            {
+                _logger.LogDebug("Duplicate: {ClassName}.{MethodName} in {FileName}:{Line}",
+                    m.ClassName, m.Name, m.FileName, m.Span.StartLinePosition.Line + 1);
+            }
         }
         return Task.FromResult(GetStepValidateResponseMessage(isValid, errorType, errorMessage, suggestion));
     }

--- a/src/Registries/IStepRegistry.cs
+++ b/src/Registries/IStepRegistry.cs
@@ -13,6 +13,7 @@ public interface IStepRegistry
 {
     bool ContainsStep(string parsedStepText);
     GaugeMethod MethodFor(string parsedStepText);
+    IEnumerable<GaugeMethod> MethodsFor(string parsedStepText);
     bool HasAlias(string stepText);
     string GetStepText(string parameterizedStepText);
     IEnumerable<string> GetStepTexts();

--- a/src/Registries/IStepRegistry.cs
+++ b/src/Registries/IStepRegistry.cs
@@ -11,14 +11,12 @@ namespace Gauge.Dotnet.Registries;
 
 public interface IStepRegistry
 {
-    bool ContainsStep(string parsedStepText);
-    GaugeMethod MethodFor(string parsedStepText);
-    IEnumerable<GaugeMethod> MethodsFor(string parsedStepText);
     bool HasAlias(string stepText);
     string GetStepText(string parameterizedStepText);
     IEnumerable<string> GetStepTexts();
-    bool HasMultipleImplementations(string parsedStepText);
+    StepLookupResult LookupStep(string parsedStepText);
     void AddStep(string stepValue, GaugeMethod stepMethod);
+    void ReplaceSteps(string filepath, IReadOnlyList<(string stepValue, GaugeMethod method)> newSteps);
     void RemoveSteps(string filepath);
     IEnumerable<StepPosition> GetStepPositions(string filePath);
     bool IsFileCached(string file);

--- a/src/Registries/StepLookupResult.cs
+++ b/src/Registries/StepLookupResult.cs
@@ -1,0 +1,14 @@
+/*----------------------------------------------------------------
+ *  Copyright (c) ThoughtWorks, Inc.
+ *  Licensed under the Apache License, Version 2.0
+ *  See LICENSE.txt in the project root for license information.
+ *----------------------------------------------------------------*/
+
+using Gauge.Dotnet.Models;
+
+namespace Gauge.Dotnet.Registries;
+
+public readonly record struct StepLookupResult(
+    bool Exists,
+    bool HasMultipleImplementations,
+    IReadOnlyList<GaugeMethod> Methods);

--- a/src/Registries/StepRegistry.cs
+++ b/src/Registries/StepRegistry.cs
@@ -89,6 +89,11 @@ public class StepRegistry : IStepRegistry
         return _registry[parsedStepText][0];
     }
 
+    public IEnumerable<GaugeMethod> MethodsFor(string parsedStepText)
+    {
+        return _registry.TryGetValue(parsedStepText, out var methods) ? methods : Enumerable.Empty<GaugeMethod>();
+    }
+
     public bool HasAlias(string stepValue)
     {
         return _registry.ContainsKey(stepValue) && _registry.GetValueOrDefault(stepValue).FirstOrDefault().HasAlias;

--- a/src/Registries/StepRegistry.cs
+++ b/src/Registries/StepRegistry.cs
@@ -13,6 +13,7 @@ namespace Gauge.Dotnet.Registries;
 [Serializable]
 public class StepRegistry : IStepRegistry
 {
+    private readonly object _lock = new();
     private Dictionary<string, List<GaugeMethod>> _registry;
 
     public StepRegistry()
@@ -20,20 +21,123 @@ public class StepRegistry : IStepRegistry
         _registry = new Dictionary<string, List<GaugeMethod>>();
     }
 
-    public int Count => _registry.Count;
+    public int Count { get { lock (_lock) { return _registry.Count; } } }
 
     public IEnumerable<string> GetStepTexts()
     {
-        return _registry.Values.SelectMany(methods => methods.Select(method => method.StepText));
+        lock (_lock)
+        {
+            return _registry.Values.SelectMany(methods => methods.Select(method => method.StepText)).ToList();
+        }
     }
 
     public void AddStep(string stepValue, GaugeMethod method)
     {
-        if (!_registry.ContainsKey(stepValue)) _registry.Add(stepValue, new List<GaugeMethod>());
-        _registry.GetValueOrDefault(stepValue).Add(method);
+        lock (_lock)
+        {
+            if (!_registry.ContainsKey(stepValue)) _registry.Add(stepValue, new List<GaugeMethod>());
+            _registry.GetValueOrDefault(stepValue).Add(method);
+        }
     }
 
     public void RemoveSteps(string filepath)
+    {
+        lock (_lock)
+        {
+            RemoveStepsInternal(filepath);
+        }
+    }
+
+    public void ReplaceSteps(string filepath, IReadOnlyList<(string stepValue, GaugeMethod method)> newSteps)
+    {
+        lock (_lock)
+        {
+            RemoveStepsInternal(filepath);
+            foreach (var (stepValue, method) in newSteps)
+                AddStepInternal(stepValue, method);
+        }
+    }
+
+    public StepLookupResult LookupStep(string parsedStepText)
+    {
+        lock (_lock)
+        {
+            if (!_registry.TryGetValue(parsedStepText, out var methods))
+                return new StepLookupResult(false, false, Array.Empty<GaugeMethod>());
+            return new StepLookupResult(true, methods.Count > 1, methods.ToList());
+        }
+    }
+
+    public IEnumerable<StepPosition> GetStepPositions(string filePath)
+    {
+        lock (_lock)
+        {
+            var positions = new List<StepPosition>();
+            foreach (var (stepValue, gaugeMethods) in _registry)
+            {
+                foreach (var m in gaugeMethods)
+                {
+                    if (!m.IsExternal && m.FileName.Equals(filePath))
+                    {
+                        var p = new StepPosition
+                        {
+                            StepValue = stepValue,
+                            Span = new Span
+                            {
+                                Start = m.Span.StartLinePosition.Line + 1,
+                                StartChar = m.Span.StartLinePosition.Character,
+                                End = m.Span.EndLinePosition.Line + 1,
+                                EndChar = m.Span.EndLinePosition.Character
+                            }
+                        };
+                        positions.Add(p);
+                    }
+                }
+            }
+            return positions;
+        }
+    }
+
+    public bool HasAlias(string stepValue)
+    {
+        lock (_lock)
+        {
+            return _registry.ContainsKey(stepValue) && _registry.GetValueOrDefault(stepValue).FirstOrDefault().HasAlias;
+        }
+    }
+
+    public string GetStepText(string stepValue)
+    {
+        lock (_lock)
+        {
+            return _registry.ContainsKey(stepValue) ? _registry[stepValue][0].StepText : string.Empty;
+        }
+    }
+
+    public void Clear()
+    {
+        lock (_lock) { _registry = new Dictionary<string, List<GaugeMethod>>(); }
+    }
+
+    public IEnumerable<string> AllSteps()
+    {
+        lock (_lock) { return _registry.Keys.ToList(); }
+    }
+
+    public bool IsFileCached(string file)
+    {
+        lock (_lock)
+        {
+            foreach (var gaugeMethods in _registry.Values)
+            {
+                if (gaugeMethods.Any(method => file.Equals(method.FileName)))
+                    return true;
+            }
+            return false;
+        }
+    }
+
+    private void RemoveStepsInternal(string filepath)
     {
         var newRegistry = new Dictionary<string, List<GaugeMethod>>();
         foreach (var (key, gaugeMethods) in _registry)
@@ -41,87 +145,13 @@ public class StepRegistry : IStepRegistry
             var methods = gaugeMethods.Where(method => !filepath.Equals(method.FileName)).ToList();
             if (methods.Count > 0) newRegistry[key] = methods;
         }
-
         _registry = newRegistry;
     }
 
-    public IEnumerable<StepPosition> GetStepPositions(string filePath)
+    private void AddStepInternal(string stepValue, GaugeMethod method)
     {
-        var positions = new List<StepPosition>();
-        foreach (var (stepValue, gaugeMethods) in _registry)
-        {
-            foreach (var m in gaugeMethods)
-            {
-                if (!m.IsExternal && m.FileName.Equals(filePath))
-                {
-                    var p = new StepPosition
-                    {
-                        StepValue = stepValue,
-                        Span = new Span
-                        {
-                            Start = m.Span.StartLinePosition.Line + 1,
-                            StartChar = m.Span.StartLinePosition.Character,
-                            End = m.Span.EndLinePosition.Line + 1,
-                            EndChar = m.Span.EndLinePosition.Character
-                        }
-                    };
-                    positions.Add(p);
-                }
-            }
-        }
-
-        return positions;
-    }
-
-
-    public bool ContainsStep(string parsedStepText)
-    {
-        return _registry.ContainsKey(parsedStepText);
-    }
-
-    public bool HasMultipleImplementations(string parsedStepText)
-    {
-        return _registry[parsedStepText].Count > 1;
-    }
-
-    public GaugeMethod MethodFor(string parsedStepText)
-    {
-        return _registry[parsedStepText][0];
-    }
-
-    public IEnumerable<GaugeMethod> MethodsFor(string parsedStepText)
-    {
-        return _registry.TryGetValue(parsedStepText, out var methods) ? methods : Enumerable.Empty<GaugeMethod>();
-    }
-
-    public bool HasAlias(string stepValue)
-    {
-        return _registry.ContainsKey(stepValue) && _registry.GetValueOrDefault(stepValue).FirstOrDefault().HasAlias;
-    }
-
-    public string GetStepText(string stepValue)
-    {
-        return _registry.ContainsKey(stepValue) ? _registry[stepValue][0].StepText : string.Empty;
-    }
-
-    public void Clear()
-    {
-        _registry = new Dictionary<string, List<GaugeMethod>>();
-    }
-
-
-    public IEnumerable<string> AllSteps()
-    {
-        return _registry.Keys;
-    }
-
-    public bool IsFileCached(string file)
-    {
-        foreach (var gaugeMethods in _registry.Values)
-        {
-            if (gaugeMethods.Any(method => file.Equals(method.FileName)))
-                return true;
-        }
-        return false;
+        if (!_registry.ContainsKey(stepValue))
+            _registry.Add(stepValue, new List<GaugeMethod>());
+        _registry.GetValueOrDefault(stepValue).Add(method);
     }
 }

--- a/src/dotnet.json
+++ b/src/dotnet.json
@@ -1,6 +1,6 @@
 {
   "id": "dotnet",
-  "version": "0.7.6",
+  "version": "0.7.7",
   "description": "C# support for gauge + .NET",
   "run": {
     "windows": [

--- a/test/Loaders/StaticLoaderTests.cs
+++ b/test/Loaders/StaticLoaderTests.cs
@@ -51,9 +51,9 @@ public class StaticLoaderTests
         loader.LoadStepsFromText(text, fileName);
         var registry = loader.GetStepRegistry();
 
-        ClassicAssert.True(registry.ContainsStep("goodbye"));
-        ClassicAssert.True(registry.ContainsStep("adieu"));
-        ClassicAssert.True(registry.ContainsStep("sayonara"));
+        ClassicAssert.True(registry.LookupStep("goodbye").Exists);
+        ClassicAssert.True(registry.LookupStep("adieu").Exists);
+        ClassicAssert.True(registry.LookupStep("sayonara").Exists);
         ClassicAssert.AreEqual(3, registry.Count);
     }
 
@@ -79,7 +79,7 @@ public class StaticLoaderTests
                             "}\n";
         const string fileName = @"foo.cs";
         loader.LoadStepsFromText(text, fileName);
-        ClassicAssert.True(loader.GetStepRegistry().ContainsStep("hello"));
+        ClassicAssert.True(loader.GetStepRegistry().LookupStep("hello").Exists);
         ClassicAssert.AreEqual(1, loader.GetStepRegistry().Count);
     }
 
@@ -156,7 +156,7 @@ public class StaticLoaderTests
         const string fileName = @"foo.cs";
         var filePath = Path.Combine(currentDirectory, fileName);
         loader.ReloadSteps(text, filePath);
-        ClassicAssert.False(loader.GetStepRegistry().ContainsStep("hello"));
+        ClassicAssert.False(loader.GetStepRegistry().LookupStep("hello").Exists);
         ClassicAssert.AreEqual(0, loader.GetStepRegistry().Count);
     }
 
@@ -181,7 +181,7 @@ public class StaticLoaderTests
                             "}\n";
         const string fileName = @"foo.cs";
         loader.LoadStepsFromText(text, fileName);
-        ClassicAssert.True(loader.GetStepRegistry().ContainsStep("hello"));
+        ClassicAssert.True(loader.GetStepRegistry().LookupStep("hello").Exists);
         ClassicAssert.AreEqual(1, loader.GetStepRegistry().Count);
 
         const string newText = "using Gauge.CSharp.Lib.Attributes;\n" +
@@ -202,7 +202,7 @@ public class StaticLoaderTests
 
         loader.ReloadSteps(newText, fileName);
 
-        ClassicAssert.True(loader.GetStepRegistry().ContainsStep("hola"));
+        ClassicAssert.True(loader.GetStepRegistry().LookupStep("hola").Exists);
         ClassicAssert.AreEqual(2, loader.GetStepRegistry().Count);
     }
 
@@ -245,13 +245,13 @@ public class StaticLoaderTests
 
         loader.ReloadSteps(newText, file2);
 
-        ClassicAssert.True(loader.GetStepRegistry().ContainsStep("hello"));
-        ClassicAssert.True(loader.GetStepRegistry().ContainsStep("hola"));
+        ClassicAssert.True(loader.GetStepRegistry().LookupStep("hello").Exists);
+        ClassicAssert.True(loader.GetStepRegistry().LookupStep("hola").Exists);
         ClassicAssert.AreEqual(2, loader.GetStepRegistry().Count);
 
         loader.RemoveSteps(file2);
 
-        ClassicAssert.False(loader.GetStepRegistry().ContainsStep("hola"));
+        ClassicAssert.False(loader.GetStepRegistry().LookupStep("hola").Exists);
         ClassicAssert.AreEqual(1, loader.GetStepRegistry().Count);
     }
 
@@ -278,7 +278,7 @@ public class StaticLoaderTests
                             "}\n";
         const string fileName = @"foo.cs";
         loader.LoadStepsFromText(text, fileName);
-        ClassicAssert.True(loader.GetStepRegistry().ContainsStep("hello"));
+        ClassicAssert.True(loader.GetStepRegistry().LookupStep("hello").Exists);
         ClassicAssert.AreEqual(1, loader.GetStepRegistry().Count);
     }
 
@@ -304,7 +304,7 @@ public class StaticLoaderTests
                             "}\n";
         const string fileName = @"foo.cs";
         loader.LoadStepsFromText(text, fileName);
-        ClassicAssert.True(loader.GetStepRegistry().ContainsStep("hello"));
+        ClassicAssert.True(loader.GetStepRegistry().LookupStep("hello").Exists);
         ClassicAssert.AreEqual(1, loader.GetStepRegistry().Count);
     }
 
@@ -332,7 +332,7 @@ public class StaticLoaderTests
                             "}\n";
         const string fileName = @"foo.cs";
         loader.LoadStepsFromText(text, fileName);
-        ClassicAssert.True(loader.GetStepRegistry().ContainsStep("hello"));
+        ClassicAssert.True(loader.GetStepRegistry().LookupStep("hello").Exists);
         ClassicAssert.AreEqual(1, loader.GetStepRegistry().Count);
     }
 
@@ -361,7 +361,7 @@ public class StaticLoaderTests
                             "}\n";
         const string fileName = @"foo.cs";
         loader.LoadStepsFromText(text, fileName);
-        ClassicAssert.True(loader.GetStepRegistry().ContainsStep("hello"));
+        ClassicAssert.True(loader.GetStepRegistry().LookupStep("hello").Exists);
         ClassicAssert.AreEqual(1, loader.GetStepRegistry().Count);
     }
 
@@ -392,7 +392,7 @@ public class StaticLoaderTests
                             "}\n";
         const string fileName = @"foo.cs";
         loader.LoadStepsFromText(text, fileName);
-        ClassicAssert.True(loader.GetStepRegistry().ContainsStep("hello"));
+        ClassicAssert.True(loader.GetStepRegistry().LookupStep("hello").Exists);
         ClassicAssert.AreEqual(1, loader.GetStepRegistry().Count);
     }
 
@@ -427,7 +427,7 @@ public class StaticLoaderTests
                             "}\n";
         const string fileName = @"foo.cs";
         loader.LoadStepsFromText(text, fileName);
-        ClassicAssert.True(loader.GetStepRegistry().ContainsStep("hello"));
+        ClassicAssert.True(loader.GetStepRegistry().LookupStep("hello").Exists);
         ClassicAssert.AreEqual(1, loader.GetStepRegistry().Count);
     }
 

--- a/test/Processors/ExecuteStepProcessorTests.cs
+++ b/test/Processors/ExecuteStepProcessorTests.cs
@@ -41,9 +41,9 @@ public class ExecuteStepProcessorTests
                 }
         };
         var mockStepRegistry = new Mock<IStepRegistry>();
-        mockStepRegistry.Setup(x => x.ContainsStep(parsedStepText)).Returns(true);
         var fooMethodInfo = new GaugeMethod { Name = "Foo", ParameterCount = 1 };
-        mockStepRegistry.Setup(x => x.MethodFor(parsedStepText)).Returns(fooMethodInfo);
+        mockStepRegistry.Setup(x => x.LookupStep(parsedStepText))
+            .Returns(new StepLookupResult(true, false, new[] { fooMethodInfo }));
         var mockOrchestrator = new Mock<IExecutionOrchestrator>();
         mockOrchestrator.Setup(e => e.ExecuteStep(fooMethodInfo, It.IsAny<int>(), It.IsAny<string[]>()))
             .ReturnsAsync(() => new ProtoExecutionResult { ExecutionTime = 1, Failed = false });
@@ -79,9 +79,9 @@ public class ExecuteStepProcessorTests
         };
 
         var mockStepRegistry = new Mock<IStepRegistry>();
-        mockStepRegistry.Setup(x => x.ContainsStep(parsedStepText)).Returns(true);
         var fooMethodInfo = new GaugeMethod { Name = "Foo", ParameterCount = 1 };
-        mockStepRegistry.Setup(x => x.MethodFor(parsedStepText)).Returns(fooMethodInfo);
+        mockStepRegistry.Setup(x => x.LookupStep(parsedStepText))
+            .Returns(new StepLookupResult(true, false, new[] { fooMethodInfo }));
         var mockOrchestrator = new Mock<IExecutionOrchestrator>();
         mockOrchestrator.Setup(e => e.ExecuteStep(fooMethodInfo, It.IsAny<int>(), It.IsAny<string[]>())).ReturnsAsync(() =>
             new ProtoExecutionResult
@@ -113,9 +113,9 @@ public class ExecuteStepProcessorTests
             ParsedStepText = parsedStepText
         };
         var mockStepRegistry = new Mock<IStepRegistry>();
-        mockStepRegistry.Setup(x => x.ContainsStep(parsedStepText)).Returns(true);
         var fooMethod = new GaugeMethod { Name = "Foo", ParameterCount = 1 };
-        mockStepRegistry.Setup(x => x.MethodFor(parsedStepText)).Returns(fooMethod);
+        mockStepRegistry.Setup(x => x.LookupStep(parsedStepText))
+            .Returns(new StepLookupResult(true, false, new[] { fooMethod }));
         var mockOrchestrator = new Mock<IExecutionOrchestrator>();
 
         var mockTableFormatter = new Mock<ITableFormatter>();
@@ -138,7 +138,8 @@ public class ExecuteStepProcessorTests
             ParsedStepText = parsedStepText
         };
         var mockStepRegistry = new Mock<IStepRegistry>();
-        mockStepRegistry.Setup(x => x.ContainsStep(parsedStepText)).Returns(false);
+        mockStepRegistry.Setup(x => x.LookupStep(parsedStepText))
+            .Returns(new StepLookupResult(false, false, Array.Empty<GaugeMethod>()));
         var mockOrchestrator = new Mock<IExecutionOrchestrator>();
         var mockTableFormatter = new Mock<ITableFormatter>();
 

--- a/test/Processors/StepNameProcessorTest.cs
+++ b/test/Processors/StepNameProcessorTest.cs
@@ -19,15 +19,13 @@ public class StepNameProcessorTest
             };
 
             var parsedStepText = request.StepValue;
-            const string stepText = "step1";
-            mockStepRegistry.Setup(r => r.ContainsStep(parsedStepText)).Returns(true);
-            mockStepRegistry.Setup(r => r.GetStepText(parsedStepText)).Returns(stepText);
             var gaugeMethod = new GaugeMethod
             {
-                FileName = "foo"
+                FileName = "foo",
+                StepText = "step1"
             };
-            mockStepRegistry.Setup(r => r.MethodFor(parsedStepText)).Returns(gaugeMethod);
-            mockStepRegistry.Setup(r => r.HasAlias(stepText)).Returns(false);
+            mockStepRegistry.Setup(r => r.LookupStep(parsedStepText))
+                .Returns(new StepLookupResult(true, false, new[] { gaugeMethod }));
             var stepNameProcessor = new StepNameProcessor(mockStepRegistry.Object);
 
             var response = await stepNameProcessor.Process(1, request);
@@ -46,18 +44,16 @@ public class StepNameProcessorTest
                 StepValue = "step1"
             };
             var parsedStepText = request.StepValue;
-            const string stepText = "step1";
-            mockStepRegistry.Setup(r => r.ContainsStep(parsedStepText)).Returns(true);
-            mockStepRegistry.Setup(r => r.GetStepText(parsedStepText)).Returns(stepText);
 
             var gaugeMethod = new GaugeMethod
             {
                 FileName = "foo",
+                StepText = "step1",
                 HasAlias = true,
                 Aliases = new List<string> { "step2", "step3" }
             };
-            mockStepRegistry.Setup(r => r.MethodFor(parsedStepText)).Returns(gaugeMethod);
-            mockStepRegistry.Setup(r => r.HasAlias(stepText)).Returns(true);
+            mockStepRegistry.Setup(r => r.LookupStep(parsedStepText))
+                .Returns(new StepLookupResult(true, false, new[] { gaugeMethod }));
             var stepNameProcessor = new StepNameProcessor(mockStepRegistry.Object);
 
             var response = await stepNameProcessor.Process(1, request);
@@ -77,16 +73,15 @@ public class StepNameProcessorTest
                 StepValue = "step1"
             };
             var parsedStepText = request.StepValue;
-            const string stepText = "step1";
-            mockStepRegistry.Setup(r => r.ContainsStep(parsedStepText)).Returns(true);
-            mockStepRegistry.Setup(r => r.GetStepText(parsedStepText)).Returns(stepText);
 
             var gaugeMethod = new GaugeMethod
             {
                 FileName = "foo",
+                StepText = "step1",
                 IsExternal = true
             };
-            mockStepRegistry.Setup(r => r.MethodFor(parsedStepText)).Returns(gaugeMethod);
+            mockStepRegistry.Setup(r => r.LookupStep(parsedStepText))
+                .Returns(new StepLookupResult(true, false, new[] { gaugeMethod }));
             var stepNameProcessor = new StepNameProcessor(mockStepRegistry.Object);
 
             var response = await stepNameProcessor.Process(1, request);

--- a/test/Processors/ValidateProcessorTests.cs
+++ b/test/Processors/ValidateProcessorTests.cs
@@ -4,9 +4,11 @@
  *  See LICENSE.txt in the project root for license information.
  *----------------------------------------------------------------*/
 
+using Gauge.Dotnet.Models;
 using Gauge.Dotnet.Processors;
 using Gauge.Dotnet.Registries;
 using Gauge.Messages;
+
 
 namespace Gauge.Dotnet.UnitTests.Processors;
 
@@ -33,14 +35,20 @@ public class ValidateProcessorTests
 
         _mockStepRegistry.Setup(registry => registry.ContainsStep("step_text_1")).Returns(true);
         _mockStepRegistry.Setup(registry => registry.HasMultipleImplementations("step_text_1")).Returns(true);
+        _mockStepRegistry.Setup(registry => registry.MethodsFor("step_text_1")).Returns(new[]
+        {
+            new GaugeMethod { Name = "StepImpl", ClassName = "StepsA", FileName = "StepsA.cs",  },
+            new GaugeMethod { Name = "StepImpl", ClassName = "StepsB", FileName = "StepsB.cs",  }
+        });
         var processor = new StepValidationProcessor(_mockStepRegistry.Object);
         var response = await processor.Process(1, request);
 
         ClassicAssert.AreEqual(false, response.IsValid);
         ClassicAssert.AreEqual(StepValidateResponse.Types.ErrorType.DuplicateStepImplementation,
             response.ErrorType);
-        ClassicAssert.AreEqual("Multiple step implementations found for : step_text_1",
-            response.ErrorMessage);
+        StringAssert.Contains("Multiple step implementations found for : step_text_1", response.ErrorMessage);
+        StringAssert.Contains("StepsA.StepImpl in StepsA.cs:1", response.ErrorMessage);
+        StringAssert.Contains("StepsB.StepImpl in StepsB.cs:1", response.ErrorMessage);
         ClassicAssert.IsEmpty(response.Suggestion);
     }
 

--- a/test/Processors/ValidateProcessorTests.cs
+++ b/test/Processors/ValidateProcessorTests.cs
@@ -8,6 +8,7 @@ using Gauge.Dotnet.Models;
 using Gauge.Dotnet.Processors;
 using Gauge.Dotnet.Registries;
 using Gauge.Messages;
+using Microsoft.Extensions.Logging;
 
 
 namespace Gauge.Dotnet.UnitTests.Processors;
@@ -39,7 +40,7 @@ public class ValidateProcessorTests
                 new GaugeMethod { Name = "StepImpl", ClassName = "StepsA", FileName = "StepsA.cs" },
                 new GaugeMethod { Name = "StepImpl", ClassName = "StepsB", FileName = "StepsB.cs" }
             }));
-        var processor = new StepValidationProcessor(_mockStepRegistry.Object);
+        var processor = new StepValidationProcessor(_mockStepRegistry.Object, Mock.Of<ILogger<StepValidationProcessor>>());
         var response = await processor.Process(1, request);
 
         ClassicAssert.AreEqual(false, response.IsValid);
@@ -66,7 +67,7 @@ public class ValidateProcessorTests
         };
         _mockStepRegistry.Setup(registry => registry.LookupStep("step_text_1")).Returns(
             new StepLookupResult(false, false, Array.Empty<GaugeMethod>()));
-        var processor = new StepValidationProcessor(_mockStepRegistry.Object);
+        var processor = new StepValidationProcessor(_mockStepRegistry.Object, Mock.Of<ILogger<StepValidationProcessor>>());
         var response = await processor.Process(1, request);
 
         ClassicAssert.AreEqual(false, response.IsValid);
@@ -90,7 +91,7 @@ public class ValidateProcessorTests
         _mockStepRegistry.Setup(registry => registry.LookupStep("step_text_1")).Returns(
             new StepLookupResult(true, false, new[] { new GaugeMethod { Name = "StepImpl" } }));
 
-        var processor = new StepValidationProcessor(_mockStepRegistry.Object);
+        var processor = new StepValidationProcessor(_mockStepRegistry.Object, Mock.Of<ILogger<StepValidationProcessor>>());
         var response = await processor.Process(1, request);
 
         ClassicAssert.AreEqual(true, response.IsValid);

--- a/test/Processors/ValidateProcessorTests.cs
+++ b/test/Processors/ValidateProcessorTests.cs
@@ -33,13 +33,12 @@ public class ValidateProcessorTests
             NumberOfParameters = 0
         };
 
-        _mockStepRegistry.Setup(registry => registry.ContainsStep("step_text_1")).Returns(true);
-        _mockStepRegistry.Setup(registry => registry.HasMultipleImplementations("step_text_1")).Returns(true);
-        _mockStepRegistry.Setup(registry => registry.MethodsFor("step_text_1")).Returns(new[]
-        {
-            new GaugeMethod { Name = "StepImpl", ClassName = "StepsA", FileName = "StepsA.cs",  },
-            new GaugeMethod { Name = "StepImpl", ClassName = "StepsB", FileName = "StepsB.cs",  }
-        });
+        _mockStepRegistry.Setup(registry => registry.LookupStep("step_text_1")).Returns(
+            new StepLookupResult(true, true, new[]
+            {
+                new GaugeMethod { Name = "StepImpl", ClassName = "StepsA", FileName = "StepsA.cs" },
+                new GaugeMethod { Name = "StepImpl", ClassName = "StepsB", FileName = "StepsB.cs" }
+            }));
         var processor = new StepValidationProcessor(_mockStepRegistry.Object);
         var response = await processor.Process(1, request);
 
@@ -65,6 +64,8 @@ public class ValidateProcessorTests
                 StepValue = "step_text_1"
             }
         };
+        _mockStepRegistry.Setup(registry => registry.LookupStep("step_text_1")).Returns(
+            new StepLookupResult(false, false, Array.Empty<GaugeMethod>()));
         var processor = new StepValidationProcessor(_mockStepRegistry.Object);
         var response = await processor.Process(1, request);
 
@@ -86,8 +87,8 @@ public class ValidateProcessorTests
             NumberOfParameters = 0
         };
 
-        _mockStepRegistry.Setup(registry => registry.ContainsStep("step_text_1")).Returns(true);
-        _mockStepRegistry.Setup(registry => registry.HasMultipleImplementations("step_text_1")).Returns(false);
+        _mockStepRegistry.Setup(registry => registry.LookupStep("step_text_1")).Returns(
+            new StepLookupResult(true, false, new[] { new GaugeMethod { Name = "StepImpl" } }));
 
         var processor = new StepValidationProcessor(_mockStepRegistry.Object);
         var response = await processor.Process(1, request);

--- a/test/Processors/ValidateProcessorTests.cs
+++ b/test/Processors/ValidateProcessorTests.cs
@@ -46,7 +46,7 @@ public class ValidateProcessorTests
         ClassicAssert.AreEqual(false, response.IsValid);
         ClassicAssert.AreEqual(StepValidateResponse.Types.ErrorType.DuplicateStepImplementation,
             response.ErrorType);
-        StringAssert.Contains("Multiple step implementations found for : step_text_1", response.ErrorMessage);
+        StringAssert.Contains("Step: step_text_1", response.ErrorMessage);
         StringAssert.Contains("StepsA.StepImpl in StepsA.cs:1", response.ErrorMessage);
         StringAssert.Contains("StepsB.StepImpl in StepsB.cs:1", response.ErrorMessage);
         ClassicAssert.IsEmpty(response.Suggestion);

--- a/test/StepRegistryTests.cs
+++ b/test/StepRegistryTests.cs
@@ -25,8 +25,8 @@ namespace Gauge.Dotnet.UnitTests
             foreach (var pair in methods)
                 stepRegistry.AddStep(pair.Key, pair.Value);
 
-            ClassicAssert.True(stepRegistry.ContainsStep("Foo"));
-            ClassicAssert.True(stepRegistry.ContainsStep("Bar"));
+            ClassicAssert.True(stepRegistry.LookupStep("Foo").Exists);
+            ClassicAssert.True(stepRegistry.LookupStep("Bar").Exists);
         }
 
         [Test]
@@ -104,7 +104,7 @@ namespace Gauge.Dotnet.UnitTests
             foreach (var pair in methods)
                 stepRegistry.AddStep(pair.Key, pair.Value);
 
-            var method = stepRegistry.MethodFor("Foo");
+            var method = stepRegistry.LookupStep("Foo").Methods[0];
 
             ClassicAssert.AreEqual(method.Name, "Foo");
         }
@@ -164,7 +164,7 @@ namespace Gauge.Dotnet.UnitTests
                 stepRegistry.AddStep(pair.Key, pair.Value);
 
             stepRegistry.RemoveSteps("Foo.cs");
-            ClassicAssert.False(stepRegistry.ContainsStep("Foo"));
+            ClassicAssert.False(stepRegistry.LookupStep("Foo").Exists);
         }
 
         [Test]
@@ -187,7 +187,7 @@ namespace Gauge.Dotnet.UnitTests
             stepRegistry.AddStep("Click {}", method1);
             stepRegistry.AddStep("Click {}", method2);
 
-            ClassicAssert.True(stepRegistry.HasMultipleImplementations("Click {}"));
+            ClassicAssert.True(stepRegistry.LookupStep("Click {}").HasMultipleImplementations);
         }
 
         [Test]

--- a/test/StepRegistryTests.cs
+++ b/test/StepRegistryTests.cs
@@ -178,6 +178,19 @@ namespace Gauge.Dotnet.UnitTests
         }
 
         [Test]
+        public void ShouldDetectGenuineDuplicateSteps()
+        {
+            var stepRegistry = new StepRegistry();
+            var method1 = new GaugeMethod { Name = "Click", ClassName = "ActionsA", StepText = "Click <element>", FileName = "ActionsA.cs" };
+            var method2 = new GaugeMethod { Name = "Click", ClassName = "ActionsB", StepText = "Click <element>", FileName = "ActionsB.cs" };
+
+            stepRegistry.AddStep("Click {}", method1);
+            stepRegistry.AddStep("Click {}", method2);
+
+            ClassicAssert.True(stepRegistry.HasMultipleImplementations("Click {}"));
+        }
+
+        [Test]
         public void ShouldNotContainStepPositionForExternalSteps()
         {
             var stepRegistry = new StepRegistry();


### PR DESCRIPTION
In VSC Gauge shows false positives about 'Duplicate step implementation'.

I've have seen the issue for years across different projects & environments (macOS/Windows etc). It was a nightmare to debug - I added logging in many places - finally it occurred to me it's likely a race condition.

My understanding is that VSC sends gRPC messages for opened files and the these gets dispatched on separate threads. All requests share the same singleton StaticLoader and its StepRegistry - which has no synchronization.

ReloadSteps (called for Opened/Changed events) performs a two-step compound operation:
1. RemoveSteps(filepath) - rebuild the registry dictionary without this file's steps                                                                                                                                                                               
2. LoadStepsFromText(...) - re-add the steps from the file content

These two steps were not atomic. When two CacheFileRequest messages are processed concurrently for different files unpredictable results may happen resulting in VSC reporting false "duplicate step implementation" errors for steps that only have a single implementation.

Fix: Lock in StaticLoader: Added a lock (_registryLock) around all public methods that mutate the registry (ReloadSteps, RemoveSteps, LoadStepsFromText). This makes the compound remove-then-add operation in ReloadSteps atomic — no other thread can read or modify the registry between the removal and re-addition of a file's steps.

It's hard to write a deterministic unit test due to the nature of the issue (at least I don't know how to do it). I've used the fix locally and it seems promising.

For the sake of user-friendless I also enriched the error message so VSC can show to the user where the duplicates are actually found. At the moment this message is not used by Gauge(!) - it's part of the proto contract, but ignored and not relayed to VSC. I will do a Gauge PR for that (https://github.com/getgauge/gauge/pull/2837).